### PR TITLE
[ADD] : 알림 페이지 마크업 및 기능 구현

### DIFF
--- a/public/images/checkDisabled.svg
+++ b/public/images/checkDisabled.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="9" viewBox="0 0 12 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.14551 5L4.41735 7L10.097 2" stroke="#BDC8D6" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/api/alert.ts
+++ b/src/api/alert.ts
@@ -1,0 +1,54 @@
+import { instanceWithToken } from "@/api";
+import { getAlertListType } from "@/types/alert";
+const prefix = "/api/alert";
+
+const Alert = {
+  // 알림 리스트 요청
+  async v1GetAlertList(data: getAlertListType) {
+    try {
+      const url = `${prefix}`;
+      const result = await instanceWithToken.get(url, {
+        params: data,
+      });
+      return result;
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  },
+  // 알림 삭제 요청
+  async v1DeleteAlert(id: number) {
+    try {
+      const url = `${prefix}`;
+      const result = await instanceWithToken.delete(url, {
+        data: {
+          alertId: id,
+        },
+      });
+      return result;
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  },
+  // 알림 읽음 요청
+  async v1ReadAlert(alertId: number) {
+    try {
+      const url = `${prefix}/read`;
+      const result = await instanceWithToken.get(url, { params: { alertId } });
+      return result;
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  },
+  // 안 읽은 알림 수 요청
+  async v1GetUnReadCount() {
+    try {
+      const url = `${prefix}/unreadCount`;
+      const result = await instanceWithToken.get(url);
+      return result;
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  },
+};
+
+export default Alert;

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -1,12 +1,12 @@
 import { instanceWithToken } from "@/api";
 import { chatType, chatListType, chatRoomNameType } from "@/types/chat";
-const prefix = "/api";
+const prefix = "/api/chat";
 
 const Chat = {
   // 채팅 발송
   async v1AddChat(data: chatType) {
     try {
-      const url = `${prefix}/chat`;
+      const url = `${prefix}`;
       const result = await instanceWithToken.post(url, data);
       return result;
     } catch (err) {
@@ -16,7 +16,7 @@ const Chat = {
   // 채팅 목록 조회
   async v1FetchChatList(data: chatListType) {
     try {
-      const url = `${prefix}/chat/chatLog`;
+      const url = `${prefix}/chatLog`;
       const result = await instanceWithToken.post(url, data);
       return result;
     } catch (err) {
@@ -26,7 +26,7 @@ const Chat = {
   // 유저간 채팅방 존재 여부 확인 (chatRoomId = 0 이면 채팅방 없음)
   async v1IsExistChatRoom(id: number) {
     try {
-      const url = `${prefix}/chat/chatRoom?otherMemberId=${id}`;
+      const url = `${prefix}/chatRoom?otherMemberId=${id}`;
       const result = await instanceWithToken.get(url);
       return result;
     } catch (err) {
@@ -36,7 +36,7 @@ const Chat = {
   // 채팅방 만들기
   async v1AddChatRoom(id: number) {
     try {
-      const url = `${prefix}/chat/chatRoom`;
+      const url = `${prefix}/chatRoom`;
       const result = await instanceWithToken.post(url, { otherMemberId: id });
       return result;
     } catch (err) {
@@ -46,7 +46,7 @@ const Chat = {
   // 채팅방 나가기 요청
   async v1LeaveChatRoom(id: number) {
     try {
-      const url = `${prefix}/chat/chatRoom`;
+      const url = `${prefix}/chatRoom`;
       const result = await instanceWithToken.delete(url, {
         data: {
           chatRoomId: id,
@@ -60,7 +60,7 @@ const Chat = {
   // 채팅방 목록 조회
   async v1FetchChatRoomList() {
     try {
-      const url = `${prefix}/chat/chatRoom/list`;
+      const url = `${prefix}/chatRoom/list`;
       const result = await instanceWithToken.get(url);
       return result;
     } catch (err) {
@@ -70,7 +70,7 @@ const Chat = {
   // 채팅방 이름 변경 요청
   async v1UpdateChatRoomName(data: chatRoomNameType) {
     try {
-      const url = `${prefix}/chat/chatRoom/name`;
+      const url = `${prefix}/chatRoom/name`;
       const result = await instanceWithToken.post(url, data);
       return result;
     } catch (err) {

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -1,5 +1,5 @@
 import { instanceWithToken } from "@/api";
-import { chatType, chatListType } from "@/types/chat";
+import { chatType, chatListType, chatRoomNameType } from "@/types/chat";
 const prefix = "/api";
 
 const Chat = {
@@ -43,11 +43,35 @@ const Chat = {
       return Promise.reject(err);
     }
   },
+  // 채팅방 나가기 요청
+  async v1LeaveChatRoom(id: number) {
+    try {
+      const url = `${prefix}/chat/chatRoom`;
+      const result = await instanceWithToken.delete(url, {
+        data: {
+          chatRoomId: id,
+        },
+      });
+      return result;
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  },
   // 채팅방 목록 조회
   async v1FetchChatRoomList() {
     try {
       const url = `${prefix}/chat/chatRoom/list`;
       const result = await instanceWithToken.get(url);
+      return result;
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  },
+  // 채팅방 이름 변경 요청
+  async v1UpdateChatRoomName(data: chatRoomNameType) {
+    try {
+      const url = `${prefix}/chat/chatRoom/name`;
+      const result = await instanceWithToken.post(url, data);
       return result;
     } catch (err) {
       return Promise.reject(err);

--- a/src/api/club.ts
+++ b/src/api/club.ts
@@ -52,10 +52,34 @@ const Club = {
   // 모임 가입신청
   async v1SignupClub(id: number) {
     try {
-      const url = `${prefix}/signup`;
+      const url = `${prefix}/approve`;
       const result = await instanceWithToken.post(url, {
         clubId: id,
       });
+      return result;
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  },
+
+  // (임시) 모임 신청 응답(수락/거절)
+  async v1ApproveClub(approve: boolean, id: number) {
+    try {
+      const url = `${prefix}/signup`;
+      const result = await instanceWithToken.post(url, {
+        approve: approve,
+        clubSignupId: id,
+      });
+      return result;
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  },
+  // 모임별 신청받은 내역 조회
+  async v1ApplicationList(id: number) {
+    try {
+      const url = `${prefix}/applicationList/${id}`;
+      const result = await instanceWithToken.get(url);
       return result;
     } catch (err) {
       return Promise.reject(err);

--- a/src/api/common/interceptors.ts
+++ b/src/api/common/interceptors.ts
@@ -1,10 +1,10 @@
-import { getAccessToken } from "@/utils/tokenControl";
 import axios, {
   AxiosInstance,
   InternalAxiosRequestConfig,
   AxiosError,
   AxiosResponse,
 } from "axios";
+import { getAccessToken } from "@/utils/tokenControl";
 import { logout } from "@/api/login";
 
 export const setInterceptors = (instance: AxiosInstance) => {

--- a/src/api/login.ts
+++ b/src/api/login.ts
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { instance } from ".";
+import { instance, instanceWithToken } from "@/api";
 import { InputValueType } from "@/hooks/useHandleInput";
 
 interface SubmitValues {
@@ -24,7 +24,7 @@ export const useLogin = () => {
 };
 
 export const logout = async (userId: string) => {
-  await instance.get(`/api/members/logout/${userId}`);
+  await instanceWithToken.get(`/api/members/logout/${userId}`);
 };
 
 export const useSignup = () => {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -50,7 +50,6 @@ export default function Login() {
           localStorage.setItem("accessToken", response.data.accessToken);
           localStorage.setItem("refreshToken", response.data.refreshToken);
           localStorage.setItem("userId", response.data.userId);
-          socketLogin();
           router.push("/");
         }
       },
@@ -61,26 +60,6 @@ export default function Login() {
     e.preventDefault();
     window.location.href = kakaoURL;
   };
-
-  // socket 연동
-  const ws = useRef<WebSocket | null>(null);
-
-  const socketLogin = () => {
-    if (!ws.current) {
-      if (socketConnect(ws)) setSocketConnected(true);
-    }
-
-    socketDisconnect(ws);
-    socketReceiveMessage(ws);
-  };
-
-  useEffect(() => {
-    if (socketConnected) {
-      if (!ws.current) {
-        socketRequestMessage(ws);
-      }
-    }
-  }, [socketConnected]);
 
   return (
     <LoginWrapper>

--- a/src/components/alert/Alert.tsx
+++ b/src/components/alert/Alert.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import Image from "next/image";
+import {
+  AlertWrapper,
+  AlertTitle,
+  AlertTabs,
+  AlertTab,
+  AlertContents,
+  AlertList,
+  AlertItem,
+  AlertItemTop,
+  AlertItemBottom,
+  AlertItemText,
+} from "@/styles/components/alert/Alert";
+
+const Alert = () => {
+  return (
+    <AlertWrapper>
+      <AlertTitle>알림</AlertTitle>
+      <AlertTabs>
+        <AlertTab>모두</AlertTab>
+        <AlertTab>읽지않음</AlertTab>
+      </AlertTabs>
+      <AlertContents>
+        <AlertList>
+          <AlertItem>
+            <AlertItemTop>
+              <AlertItemText>만두만둘님이 모임신청을 하였습니다.</AlertItemText>
+              <Image
+                src={"/images/emailSuccess.svg"}
+                width={15}
+                height={12}
+                alt="Alert Check Icon"
+                className="succe"
+              />
+              <Image
+                src={"/images/emailFail.svg"}
+                width={15}
+                height={12}
+                alt="Alert Delete Icon"
+              />
+            </AlertItemTop>
+            <AlertItemBottom>
+              <span>5분전</span>
+            </AlertItemBottom>
+          </AlertItem>
+        </AlertList>
+      </AlertContents>
+    </AlertWrapper>
+  );
+};
+
+export default Alert;

--- a/src/components/alert/Alert.tsx
+++ b/src/components/alert/Alert.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useState } from "react";
 import Image from "next/image";
+import { useQuery, useMutation } from "@tanstack/react-query";
 import {
   AlertWrapper,
   AlertTitle,
@@ -12,38 +13,125 @@ import {
   AlertItemBottom,
   AlertItemText,
 } from "@/styles/components/alert/Alert";
+import { elapsedTime } from "@/utils/dateFormat";
+import { IAlertList } from "@/types/alert";
+// api
+import Api from "@/api/alert";
+import { getAlertListType } from "@/types/alert";
 
 const Alert = () => {
+  const [alertAll, setAlertAll] = useState<boolean>(true);
+  const [options, setOptions] = useState<getAlertListType>({
+    isAllOrNotRead: true,
+    lastSeq: -1,
+    listCount: 20,
+  });
+  const [alertList, setAlertList] = useState<Array<IAlertList>>([]);
+
+  /*
+  const { isLoading, error, data, refetch } = useQuery(
+    ["alertList"],
+    () => Api.v1GetAlertList(options),
+    {
+      refetchOnWindowFocus: true,
+      onSuccess: (res) => {
+        if (res.data.data) {
+          const { alertList } = res.data.data;
+          setAlertList(alertList);
+        }
+      },
+    },
+  );*/
+
+  const { mutate: checkAlert } = useMutation({
+    mutationFn: (id: number) => Api.v1ReadAlert(id),
+    onSuccess: (res) => {
+      // refetch();
+    },
+  });
+
+  const { mutate: deleteAlert } = useMutation({
+    mutationFn: (id: number) => Api.v1DeleteAlert(id),
+    onSuccess: (res) => {
+      // refetch();
+    },
+  });
+
+  const getAllAlert = () => {
+    setAlertAll(true);
+    setOptions({
+      ...options,
+      isAllOrNotRead: true,
+    });
+  };
+
+  const getUnReadAlert = () => {
+    setAlertAll(false);
+    setOptions({
+      ...options,
+      isAllOrNotRead: false,
+    });
+  };
+
   return (
     <AlertWrapper>
       <AlertTitle>알림</AlertTitle>
       <AlertTabs>
-        <AlertTab>모두</AlertTab>
-        <AlertTab>읽지않음</AlertTab>
+        <AlertTab
+          className={`${alertAll ? "check" : ""}`}
+          onClick={() => getAllAlert()}
+        >
+          모두
+        </AlertTab>
+        <AlertTab
+          className={`${!alertAll ? "check" : ""}`}
+          onClick={() => getUnReadAlert()}
+        >
+          읽지않음
+        </AlertTab>
       </AlertTabs>
       <AlertContents>
         <AlertList>
-          <AlertItem>
-            <AlertItemTop>
-              <AlertItemText>만두만둘님이 모임신청을 하였습니다.</AlertItemText>
-              <Image
-                src={"/images/emailSuccess.svg"}
-                width={15}
-                height={12}
-                alt="Alert Check Icon"
-                className="succe"
-              />
-              <Image
-                src={"/images/emailFail.svg"}
-                width={15}
-                height={12}
-                alt="Alert Delete Icon"
-              />
-            </AlertItemTop>
-            <AlertItemBottom>
-              <span>5분전</span>
-            </AlertItemBottom>
-          </AlertItem>
+          {alertList &&
+            alertList.map((item, index) => {
+              return (
+                <AlertItem
+                  key={`alert${index}`}
+                  className={`${item.checkStatue ? "disabled" : ""}`}
+                >
+                  <AlertItemTop>
+                    <AlertItemText>{item.alertContent}</AlertItemText>
+                    {!item.checkStatue ? (
+                      <Image
+                        src={"/images/emailSuccess.svg"}
+                        width={15}
+                        height={12}
+                        alt="Alert Check Icon"
+                        onClick={() => checkAlert(item.alertId)}
+                      />
+                    ) : (
+                      <Image
+                        src={"/images/checkDisabled.svg"}
+                        width={15}
+                        height={12}
+                        alt="Alert Disabled Icon"
+                        className="disabled"
+                      />
+                    )}
+                    <Image
+                      src={"/images/emailFail.svg"}
+                      width={15}
+                      height={12}
+                      alt="Alert Delete Icon"
+                      onClick={() => deleteAlert(item.alertId)}
+                    />
+                  </AlertItemTop>
+                  <AlertItemBottom>
+                    <span>{elapsedTime(item.alertCreateDateTime)}</span>
+                  </AlertItemBottom>
+                </AlertItem>
+              );
+            })}
         </AlertList>
       </AlertContents>
     </AlertWrapper>

--- a/src/components/chat/ChatDefaultForm.tsx
+++ b/src/components/chat/ChatDefaultForm.tsx
@@ -10,13 +10,16 @@ import {
   ChatDefaultText,
 } from "@/styles/components/chat/ChatDefaultForm";
 import TextButton from "@/components/common/TextButton";
+import { getUserId } from "@/utils/tokenControl";
 import Api from "@/api/chat";
 
 const ChatDefaultForm = () => {
   const router = useRouter();
+  const userId = typeof window !== "undefined" && Number(getUserId());
+
   const onClickShowMyClubs = async () => {
-    // const data = await Api.v1AddChatRoom(8);
-    router.push("/mypage/list/apply");
+    // const data = await Api.v1AddChatRoom(45);
+    router.push(`/mypage/list/apply/${userId}`);
     /*const data = await Api.v1AddChat({
       chatMsg: "답장부탁드려요!!",
       chatRoomId: 2,

--- a/src/components/chat/ChatMessageList.tsx
+++ b/src/components/chat/ChatMessageList.tsx
@@ -20,11 +20,13 @@ import {
   chatListState,
   chatRoomListState,
 } from "@/recoil/chat/chatState";
+import { socketChatAddState } from "@/recoil/socket/socketState";
 
 const ChatMessageList = () => {
   const checkChatRoom = useRecoilValue(checkChatRoomState);
   const chatRooms = useRecoilValue(chatRoomListState);
   const [chatList, setChatList] = useRecoilState(chatListState);
+  const socketChat = useRecoilValue(socketChatAddState);
   const userId = typeof window !== "undefined" && Number(getUserId());
 
   const { mutate: getChatList } = useMutation({
@@ -51,7 +53,7 @@ const ChatMessageList = () => {
       lastChatSeq: -1,
       listCount: 20,
     });
-  }, [chatRooms]);
+  }, [chatRooms, socketChat]);
 
   return (
     <ChatList>

--- a/src/components/chat/ChatMessageList.tsx
+++ b/src/components/chat/ChatMessageList.tsx
@@ -27,7 +27,7 @@ const ChatMessageList = () => {
   const checkChatRoom = useRecoilValue(checkChatRoomState);
   // const [chats, setChats] = useRecoilState(chatListState);
   const [chatList, setChatList] = useState<Array<ChatListProps>>([]);
-  const userId = Number(getUserId());
+  const userId = typeof window !== "undefined" && Number(getUserId());
 
   const { mutate: getChatList } = useMutation({
     mutationFn: (data: chatListType) => Api.v1FetchChatList(data),

--- a/src/components/chat/ChatMessageList.tsx
+++ b/src/components/chat/ChatMessageList.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/styles/components/chat/ChatRoomForm";
 import { chatListType } from "@/types/chat";
 import { getUserId } from "@/utils/tokenControl";
+import { getDateFormat, getTimeFormat } from "@/utils/dateFormat";
 // api
 import Api from "@/api/chat";
 // recoil
@@ -63,13 +64,13 @@ const ChatMessageList = () => {
             <ChatItem key={index}>
               {(index === 0 || index % 4 === 0) && (
                 <ChatDateBox>
-                  <ChatDate>{item.dateTime.toString()}</ChatDate>
+                  <ChatDate>{getDateFormat(item.dateTime)}</ChatDate>
                 </ChatDateBox>
               )}
               <ChatContentBox
                 className={`${item.senderMemberId !== userId && "opposite"}`}
               >
-                <ChatTime>{item.dateTime.toString()}</ChatTime>
+                <ChatTime>{getTimeFormat(item.dateTime)}</ChatTime>
                 <ChatContent>{item.message}</ChatContent>
               </ChatContentBox>
             </ChatItem>

--- a/src/components/chat/ChatMessageList.tsx
+++ b/src/components/chat/ChatMessageList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect } from "react";
 import { useMutation } from "@tanstack/react-query";
 import {
   ChatList,
@@ -9,34 +9,31 @@ import {
   ChatTime,
   ChatContent,
 } from "@/styles/components/chat/ChatRoomForm";
-import { chatListType, ChatListType } from "@/types/chat";
+import { chatListType } from "@/types/chat";
 import { getUserId } from "@/utils/tokenControl";
 // api
 import Api from "@/api/chat";
 // recoil
 import { useRecoilValue, useRecoilState } from "recoil";
-import { checkChatRoomState, chatListState } from "@/recoil/chat/chatState";
-
-interface ChatListProps {
-  chatId: number;
-  dateTime: Date;
-  message: string;
-}
+import {
+  checkChatRoomState,
+  chatListState,
+  chatRoomListState,
+} from "@/recoil/chat/chatState";
 
 const ChatMessageList = () => {
   const checkChatRoom = useRecoilValue(checkChatRoomState);
-  // const [chats, setChats] = useRecoilState(chatListState);
-  const [chatList, setChatList] = useState<Array<ChatListProps>>([]);
+  const chatRooms = useRecoilValue(chatRoomListState);
+  const [chatList, setChatList] = useRecoilState(chatListState);
   const userId = typeof window !== "undefined" && Number(getUserId());
 
   const { mutate: getChatList } = useMutation({
     mutationFn: (data: chatListType) => Api.v1FetchChatList(data),
     onSuccess: (res) => {
       const { chatList } = res.data.data;
-      setChatList(chatList);
-    },
-    onError: () => {
-      // interceptor에서 공통 error 처리
+      setChatList({
+        chatList: chatList,
+      });
     },
   });
 
@@ -46,25 +43,29 @@ const ChatMessageList = () => {
       lastChatSeq: -1,
       listCount: 20,
     });
-  }, []);
+  }, [checkChatRoom]);
+
+  useEffect(() => {
+    getChatList({
+      chatRoomId: checkChatRoom.chatRoomId,
+      lastChatSeq: -1,
+      listCount: 20,
+    });
+  }, [chatRooms]);
 
   return (
     <ChatList>
-      {chatList &&
-        chatList.map((item, index) => {
+      {chatList.chatList &&
+        chatList.chatList.map((item, index) => {
           return (
             <ChatItem key={index}>
               {(index === 0 || index % 4 === 0) && (
                 <ChatDateBox>
-                  안녕하세요
                   <ChatDate>{item.dateTime.toString()}</ChatDate>
                 </ChatDateBox>
               )}
-              {/*<ChatContentBox
-                className={`${item.memberId !== userId && "opposite"}`}
-              >*/}
               <ChatContentBox
-                className={`${item.chatId !== userId && "opposite"}`}
+                className={`${item.senderMemberId !== userId && "opposite"}`}
               >
                 <ChatTime>{item.dateTime.toString()}</ChatTime>
                 <ChatContent>{item.message}</ChatContent>

--- a/src/components/chat/ChatRoomFormBottom.tsx
+++ b/src/components/chat/ChatRoomFormBottom.tsx
@@ -1,19 +1,79 @@
-import React from "react";
+import React, { useState } from "react";
 import Image from "next/image";
+import { useQuery, useMutation } from "@tanstack/react-query";
 import {
   ChatInputForm,
   ChatInput,
 } from "@/styles/components/chat/ChatRoomForm";
+import { chatType } from "@/types/chat";
+// api
+import Api from "@/api/chat";
+// recoil
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { checkChatRoomState, chatRoomListState } from "@/recoil/chat/chatState";
 
 const ChatRoomFormBottom = () => {
+  const checkChatRoom = useRecoilValue(checkChatRoomState);
+  const [message, setMessage] = useState<string>("");
+  const setChatRooms = useSetRecoilState(chatRoomListState);
+
+  const { isLoading, error, data, refetch } = useQuery(
+    ["chatRoomList"],
+    () => Api.v1FetchChatRoomList(),
+    {
+      onSuccess: (res) => {
+        if (res.data.data) {
+          const { chatRoomList } = res.data.data;
+          setChatRooms({
+            chatRoomList: [...chatRoomList],
+          });
+        }
+      },
+    },
+  );
+
+  const { mutate: addMessage } = useMutation({
+    mutationFn: (data: chatType) => Api.v1AddChat(data),
+    onSuccess: (res) => {
+      setMessage("");
+      refetch();
+    },
+  });
+
+  const onChangeMessage = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setMessage(e.target.value);
+  };
+
+  const onClickAddMessage = () => {
+    const data = {
+      chatMsg: message,
+      chatRoomId: checkChatRoom.chatRoomId,
+    };
+
+    addMessage(data);
+  };
+
+  const handleOnKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      onClickAddMessage();
+    }
+  };
+
   return (
     <ChatInputForm>
-      <ChatInput type="text" placeholder="메시지 입력" />
+      <ChatInput
+        type="text"
+        value={message}
+        placeholder="메시지 입력"
+        onKeyDown={handleOnKeyPress}
+        onChange={(e) => onChangeMessage(e)}
+      />
       <Image
         src="/images/chatSend.svg"
         width={21}
         height={21}
         alt="Chat Message Send Icon"
+        onClick={() => onClickAddMessage()}
       />
     </ChatInputForm>
   );

--- a/src/components/chat/ChatRoomFormBottom.tsx
+++ b/src/components/chat/ChatRoomFormBottom.tsx
@@ -14,8 +14,8 @@ import { checkChatRoomState, chatRoomListState } from "@/recoil/chat/chatState";
 
 const ChatRoomFormBottom = () => {
   const checkChatRoom = useRecoilValue(checkChatRoomState);
-  const [message, setMessage] = useState<string>("");
   const setChatRooms = useSetRecoilState(chatRoomListState);
+  const [message, setMessage] = useState<string>("");
 
   const { isLoading, error, data, refetch } = useQuery(
     ["chatRoomList"],

--- a/src/components/chat/ChatRoomListAside.tsx
+++ b/src/components/chat/ChatRoomListAside.tsx
@@ -25,6 +25,7 @@ const ChatRoomListAside = () => {
   const router = useRouter();
   const [chatRooms, setChatRooms] = useRecoilState(chatRoomListState);
   const [checkChatRoom, setCheckChatRoom] = useRecoilState(checkChatRoomState);
+
   const { isLoading, error, data } = useQuery(
     ["chatRoomList"],
     () => Api.v1FetchChatRoomList(),

--- a/src/components/chat/ChatRoomListAside.tsx
+++ b/src/components/chat/ChatRoomListAside.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -18,15 +18,17 @@ import { ChatRoomType } from "@/types/chat";
 // api
 import Api from "@/api/chat";
 // recoil
-import { useRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import { chatRoomListState, checkChatRoomState } from "@/recoil/chat/chatState";
+import { socketChatAddState } from "@/recoil/socket/socketState";
 
 const ChatRoomListAside = () => {
   const router = useRouter();
   const [chatRooms, setChatRooms] = useRecoilState(chatRoomListState);
   const [checkChatRoom, setCheckChatRoom] = useRecoilState(checkChatRoomState);
+  const socketChat = useRecoilValue(socketChatAddState);
 
-  const { isLoading, error, data } = useQuery(
+  const { isLoading, error, data, refetch } = useQuery(
     ["chatRoomList"],
     () => Api.v1FetchChatRoomList(),
     {
@@ -51,6 +53,10 @@ const ChatRoomListAside = () => {
     });
     router.push(`/chat/${item.chatRoomId}`);
   };
+
+  useEffect(() => {
+    refetch();
+  }, [socketChat]);
 
   return (
     <ChatRoomListWrapper>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -11,7 +11,7 @@ import {
   WrapHeader,
   WrapLogo,
 } from "@/styles/components/layout/Header";
-import { getUserId } from "@/utils/tokenControl";
+import { getUserId, clearToken } from "@/utils/tokenControl";
 import Image from "next/image";
 // socket
 import useSocket from "@/hooks/useSocket";
@@ -30,22 +30,20 @@ export default function Header() {
   const ws = useRef<WebSocket | null>(null);
   const userId = typeof window !== "undefined" && getUserId();
 
-  const handleLogout = (e: React.MouseEvent<HTMLAnchorElement>) => {
+  const handleLogout = async (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
-    if (userId) logout(userId);
-
-    localStorage.removeItem("accessToken");
-    localStorage.removeItem("refreshToken");
-    localStorage.removeItem("userId");
-    setIsLoggedIn(false);
-    router.replace("/");
+    if (userId) {
+      await logout(userId);
+      clearToken();
+      setIsLoggedIn(false);
+      router.replace("/");
+    }
   };
 
   const socketLogin = () => {
     if (!ws.current) {
       if (socketConnect(ws)) setSocketConnected(true);
     }
-
     socketDisconnect(ws);
     socketReceiveMessage(ws);
   };

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -11,6 +11,8 @@ import {
   WrapHeader,
   WrapLogo,
 } from "@/styles/components/layout/Header";
+import { AlertBadge } from "@/styles/components/alert/Alert";
+import Alert from "@/components/alert/Alert";
 import { getUserId, clearToken } from "@/utils/tokenControl";
 import Image from "next/image";
 // socket
@@ -20,6 +22,7 @@ export default function Header() {
   const path = usePathname();
   const router = useRouter();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [isAlertOpen, setIsAlertOpen] = useState<boolean>(false);
   const [socketConnected, setSocketConnected] = useState<boolean>(false);
   const [
     socketConnect,
@@ -96,11 +99,11 @@ export default function Header() {
             </MenuIconItem>
             <MenuIconItem
               href="#"
-              onClick={(e) => {
-                e.preventDefault();
-              }}
+              onClick={() => setIsAlertOpen((item) => !item)}
+              className="alert"
             >
               <Image src="/images/bell.svg" width={27} height={23} alt="알림" />
+              <AlertBadge>14</AlertBadge>
             </MenuIconItem>
             <MenuItem
               href="#"
@@ -116,6 +119,7 @@ export default function Header() {
             <MenuItem href="/signup">회원가입</MenuItem>
           </>
         )}
+        {isAlertOpen && <Alert />}
       </Menu>
     </WrapHeader>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -20,6 +20,9 @@ import Image from "next/image";
 import useSocket from "@/hooks/useSocket";
 // api
 import Api from "@/api/alert";
+// recoil
+import { useRecoilValue } from "recoil";
+import { socketAlertMsgState } from "@/recoil/socket/socketState";
 
 export default function Header() {
   const path = usePathname();
@@ -28,6 +31,7 @@ export default function Header() {
   const [isAlertOpen, setIsAlertOpen] = useState<boolean>(false);
   const [unReadAlertCnt, setUnReadAlertCnt] = useState<number>(0);
   const [socketConnected, setSocketConnected] = useState<boolean>(false);
+  const socketAlertMsg = useRecoilValue(socketAlertMsgState);
   const [
     socketConnect,
     socketDisconnect,
@@ -76,6 +80,10 @@ export default function Header() {
       socketLogin();
     }
   }, [path]);
+
+  useEffect(() => {
+    refetch();
+  }, [socketAlertMsg]);
 
   useEffect(() => {
     if (socketConnected) {

--- a/src/components/search/mapType/SearchItemComment.tsx
+++ b/src/components/search/mapType/SearchItemComment.tsx
@@ -39,7 +39,9 @@ const SearchItemComment = ({ clubId }: SearchItemCommentProps) => {
   const [message, setMessage] = useState<string>("");
   const [commentList, setCommentList] = useState<Array<CommentType>>([]);
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
-  const memberId = Number(getUserId() || -1);
+  const memberId = Number(
+    (typeof window !== "undefined" && Number(getUserId())) || -1,
+  );
 
   const onChangeMessage = (e: React.ChangeEvent<HTMLInputElement>) => {
     setMessage(e.target.value);

--- a/src/components/search/mapType/SearchItemDetail.tsx
+++ b/src/components/search/mapType/SearchItemDetail.tsx
@@ -44,7 +44,7 @@ const SearchItemDetail = () => {
       <SearchDetailContentBox>
         <Image src="/images/user.svg" width={25} height={23} alt="User Icon" />
         <SearchDetailContent>
-          {clubDetail.isRecruit ? "모집중" : "모집완료"}{" "}
+          {clubDetail.isRecruit ? "모집중" : "모집완료"}
           {clubDetail.memberCount}/{clubDetail.clubMaximum}
         </SearchDetailContent>
       </SearchDetailContentBox>

--- a/src/components/search/mapType/SearchItemSummary.tsx
+++ b/src/components/search/mapType/SearchItemSummary.tsx
@@ -33,9 +33,6 @@ const SearchItemSummary = ({ clubId }: SearchItemSummaryProps) => {
       const { code } = res.data;
       if (code === 200) console.log("신청하기 완료");
     },
-    onError: () => {
-      // interceptor에서 공통 error 처리
-    },
   });
 
   const onClickClubSignup = () => {

--- a/src/hooks/useSocket.tsx
+++ b/src/hooks/useSocket.tsx
@@ -3,6 +3,7 @@ import { MutableRefObject } from "react";
 import { getUserId } from "@/utils/tokenControl";
 import { useSetRecoilState } from "recoil";
 import {
+  socketAlertMsgState,
   socketChatAddState,
   socketCommentAddState,
   socketCommentDeleteState,
@@ -14,6 +15,7 @@ const useSocket = () => {
   const setSocketAddComment = useSetRecoilState(socketCommentAddState);
   const setSocketDeleteComment = useSetRecoilState(socketCommentDeleteState);
   const setSocketAddChat = useSetRecoilState(socketChatAddState);
+  const setSocketAlertMsg = useSetRecoilState(socketAlertMsgState);
 
   const socketConnect = (
     ws: MutableRefObject<WebSocket | null>,
@@ -83,6 +85,10 @@ const useSocket = () => {
           senderNickname: data.senderNickname,
         });
       } else {
+        setSocketAlertMsg({
+          alertType: data.alertType,
+          alertId: data.alertId,
+        });
       }
     };
   };

--- a/src/hooks/useSocket.tsx
+++ b/src/hooks/useSocket.tsx
@@ -3,6 +3,7 @@ import { MutableRefObject } from "react";
 import { getUserId } from "@/utils/tokenControl";
 import { useSetRecoilState } from "recoil";
 import {
+  socketChatAddState,
   socketCommentAddState,
   socketCommentDeleteState,
 } from "@/recoil/socket/socketState";
@@ -12,6 +13,7 @@ const webSocketUrl = `${process.env.NEXT_PUBLIC_SOCKET_BASE_URL}/api/chatting`;
 const useSocket = () => {
   const setSocketAddComment = useSetRecoilState(socketCommentAddState);
   const setSocketDeleteComment = useSetRecoilState(socketCommentDeleteState);
+  const setSocketAddChat = useSetRecoilState(socketChatAddState);
 
   const socketConnect = (
     ws: MutableRefObject<WebSocket | null>,
@@ -73,6 +75,13 @@ const useSocket = () => {
           });
         }
       } else if (response.type === "chat") {
+        setSocketAddChat({
+          chatRoomId: data.chatRoomId,
+          chatId: data.chatId,
+          chat: data.chat,
+          senderMemberId: data.senderMemberId,
+          senderNickname: data.senderNickname,
+        });
       } else {
       }
     };

--- a/src/recoil/socket/socketState.ts
+++ b/src/recoil/socket/socketState.ts
@@ -1,5 +1,6 @@
 import { atom } from "recoil";
 import {
+  socketChatAddType,
   socketCommentAddMsgType,
   socketCommentDeleteMsgType,
 } from "@/types/socket";
@@ -25,4 +26,15 @@ const socketCommentDeleteState = atom<socketCommentDeleteMsgType>({
   },
 });
 
-export { socketCommentAddState, socketCommentDeleteState };
+const socketChatAddState = atom<socketChatAddType>({
+  key: "socketChatAddState",
+  default: {
+    chatRoomId: -1,
+    chatId: -1,
+    chat: "",
+    senderMemberId: -1,
+    senderNickname: "",
+  },
+});
+
+export { socketCommentAddState, socketCommentDeleteState, socketChatAddState };

--- a/src/recoil/socket/socketState.ts
+++ b/src/recoil/socket/socketState.ts
@@ -1,5 +1,6 @@
 import { atom } from "recoil";
 import {
+  socketAlertMsgType,
   socketChatAddType,
   socketCommentAddMsgType,
   socketCommentDeleteMsgType,
@@ -37,4 +38,17 @@ const socketChatAddState = atom<socketChatAddType>({
   },
 });
 
-export { socketCommentAddState, socketCommentDeleteState, socketChatAddState };
+const socketAlertMsgState = atom<socketAlertMsgType>({
+  key: "socketAlertMsgState",
+  default: {
+    alertType: "",
+    alertId: -1,
+  },
+});
+
+export {
+  socketCommentAddState,
+  socketCommentDeleteState,
+  socketChatAddState,
+  socketAlertMsgState,
+};

--- a/src/styles/components/alert/Alert.tsx
+++ b/src/styles/components/alert/Alert.tsx
@@ -22,7 +22,6 @@ const AlertTitle = styled.div`
 
 const AlertTabs = styled.div`
   display: flex;
-  gap: 0.5rem;
   margin-bottom: 3px;
 `;
 
@@ -30,9 +29,13 @@ const AlertTab = styled.div`
   font-size: 14px;
   font-weight: 600;
   color: #0f47a1;
-  background-color: #ecf2ff;
   padding: 2px 15px;
   border-radius: 20px;
+  cursor: pointer;
+
+  &.check {
+    background-color: #ecf2ff;
+  }
 `;
 
 const AlertContents = styled.div`
@@ -66,6 +69,11 @@ const AlertItem = styled.li`
   font-size: 14px;
   font-weight: 600;
   color: #000;
+
+  &.disabled {
+    font-weight: 400;
+    color: #bdc8d6;
+  }
 `;
 
 const AlertItemTop = styled.div`
@@ -79,6 +87,14 @@ const AlertItemTop = styled.div`
 
   & > img:hover {
     opacity: 0.7;
+  }
+
+  & > img {
+    cursor: pointer;
+
+    &.disabled {
+      cursor: none;
+    }
   }
 `;
 

--- a/src/styles/components/alert/Alert.tsx
+++ b/src/styles/components/alert/Alert.tsx
@@ -1,0 +1,129 @@
+import styled from "styled-components";
+
+const AlertWrapper = styled.div`
+  position: absolute;
+  top: 4.5rem;
+  right: 1rem;
+  display: flex;
+  width: 22rem;
+  flex-direction: column;
+  background-color: #fff;
+  box-shadow: 0 0 0.35rem rgba(0, 0, 0, 0.25);
+  border-radius: 5px;
+  padding: 10px 15px 15px;
+  gap: 0.5rem;
+`;
+
+const AlertTitle = styled.div`
+  font-size: 18px;
+  font-weight: 600;
+  color: #000;
+`;
+
+const AlertTabs = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 3px;
+`;
+
+const AlertTab = styled.div`
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f47a1;
+  background-color: #ecf2ff;
+  padding: 2px 15px;
+  border-radius: 20px;
+`;
+
+const AlertContents = styled.div`
+  max-height: 18rem;
+  overflow-y: auto;
+
+  &::-webkit-scrollbar {
+    width: 7px;
+    border-radius: 10px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.2);
+    border-radius: 10px;
+  }
+
+  &::-webkit-scrollbar-track {
+    margin: 8px;
+  }
+`;
+
+const AlertList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+const AlertItem = styled.li`
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  font-weight: 600;
+  color: #000;
+`;
+
+const AlertItemTop = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 2px;
+
+  & > img:first-of-type {
+    margin-right: 5px;
+  }
+
+  & > img:hover {
+    opacity: 0.7;
+  }
+`;
+
+const AlertItemBottom = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  width: 15.5rem;
+  font-size: 14px;
+  font-weight: 600;
+  color: #a9a9a9;
+`;
+
+const AlertItemText = styled.div`
+  display: block;
+  width: 16rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const AlertBadge = styled.div`
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  top: 10px;
+  right: 165px;
+  background-color: red;
+  color: #fff;
+  font-size: 11px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50px;
+`;
+
+export {
+  AlertWrapper,
+  AlertTitle,
+  AlertTabs,
+  AlertTab,
+  AlertContents,
+  AlertList,
+  AlertItem,
+  AlertItemTop,
+  AlertItemBottom,
+  AlertItemText,
+  AlertBadge,
+};

--- a/src/styles/components/chat/ChatRoomListAside.tsx
+++ b/src/styles/components/chat/ChatRoomListAside.tsx
@@ -63,7 +63,7 @@ const ChatRoomItemText = styled.div`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  width: 20rem;
+  width: 19.5rem;
   font-size: 0.9rem;
   letter-spacing: 0.25px;
   color: #0d3471;

--- a/src/styles/components/layout/Header.tsx
+++ b/src/styles/components/layout/Header.tsx
@@ -7,6 +7,7 @@ const WrapHeader = styled.header`
   display: flex;
   justify-content: space-between;
   padding: 20px 30px 15px;
+  position: relative;
 `;
 
 const WrapLogo = styled(Link)`

--- a/src/types/alert.ts
+++ b/src/types/alert.ts
@@ -1,0 +1,14 @@
+export interface getAlertListType {
+  isAllOrNotRead: boolean;
+  lastSeq: number;
+  listCount: number;
+}
+
+export interface IAlertList {
+  alertContent: string;
+  alertCreateDateTime: Date;
+  alertId: number;
+  alertReadDateTime: Date;
+  alertType: string;
+  checkStatue: boolean;
+}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -24,6 +24,8 @@ export interface ChatResponseType {
   chatId: number;
   dateTime: Date;
   message: string;
+  senderMemberId: number;
+  senderNickname: string;
 }
 
 export interface ChatListType {
@@ -33,4 +35,9 @@ export interface ChatListType {
 export interface ChatRequestType {
   chatMsg: string;
   chatRoomId: number;
+}
+
+export interface chatRoomNameType {
+  chatRoomId: number;
+  chatRoomName: string;
 }

--- a/src/types/socket.ts
+++ b/src/types/socket.ts
@@ -12,3 +12,11 @@ export interface socketCommentDeleteMsgType {
   method: string;
   commentId: number;
 }
+
+export interface socketChatAddType {
+  chatRoomId: number;
+  chatId: number;
+  chat: string;
+  senderMemberId: number;
+  senderNickname: string;
+}

--- a/src/types/socket.ts
+++ b/src/types/socket.ts
@@ -20,3 +20,8 @@ export interface socketChatAddType {
   senderMemberId: number;
   senderNickname: string;
 }
+
+export interface socketAlertMsgType {
+  alertType: string;
+  alertId: number;
+}

--- a/src/utils/dateFormat.ts
+++ b/src/utils/dateFormat.ts
@@ -54,3 +54,28 @@ export const elapsedTime = (date: Date) => {
   }
   return "방금 전";
 };
+
+export const getDateFormat = (date: string) => {
+  const weekNames = ["일", "월", "화", "수", "목", "금", "토"];
+  const newDate = new Date(date);
+  const year = newDate.getFullYear();
+  const month = newDate.getMonth();
+  const day = newDate.getDate();
+  const week = weekNames[newDate.getDay()];
+
+  const newMonth = month + 1 < 10 ? `0${month + 1}` : `${month + 1}`;
+  const newDay = day < 10 ? `0${day}` : `${day}`;
+
+  return `${year}년 ${newMonth}월 ${newDay}일 ${week}요일`;
+};
+
+export const getTimeFormat = (date: string) => {
+  const newDate = new Date(date);
+  const hour = newDate.getHours();
+  const minute = newDate.getMinutes();
+  const timezone = hour < 12 ? "오전" : "오후";
+  const newHour = hour > 12 ? hour - 12 : hour;
+  const newMinute = minute < 10 ? `0${minute}` : `${minute}`;
+
+  return `${timezone} ${newHour}시 ${newMinute}분`;
+};

--- a/src/utils/dateFormat.ts
+++ b/src/utils/dateFormat.ts
@@ -55,7 +55,7 @@ export const elapsedTime = (date: Date) => {
   return "방금 전";
 };
 
-export const getDateFormat = (date: string) => {
+export const getDateFormat = (date: Date) => {
   const weekNames = ["일", "월", "화", "수", "목", "금", "토"];
   const newDate = new Date(date);
   const year = newDate.getFullYear();
@@ -69,7 +69,7 @@ export const getDateFormat = (date: string) => {
   return `${year}년 ${newMonth}월 ${newDay}일 ${week}요일`;
 };
 
-export const getTimeFormat = (date: string) => {
+export const getTimeFormat = (date: Date) => {
   const newDate = new Date(date);
   const hour = newDate.getHours();
   const minute = newDate.getMinutes();


### PR DESCRIPTION
## 작업사항
- [x] 알림 목록 페이지 마크업
- [x] 알림 목록 조회 기능 구현
- [x] 알림 목록 상태 수정/삭제 기능 구현
- [x] 안 읽은 알림 수 배지 출력
- [x] 소켓 연동 후 실시간 알림 갱신

## 비고
- 알림 목록 조회 경우 get request를 body ->query로 백엔드 쪽에서 수정 후 그 부분만 변경 필요

## Github 이슈
- [알림 목록 페이지 마크업](https://github.com/KangHayeonn/together-party-tonight-client/issues/60#issue-1789748248)
- [알림 기능 구현](https://github.com/KangHayeonn/together-party-tonight-client/issues/96#issue-1827736754)

## 작업일자
- 2023.07.30

<br>
