### PR TITLE
[ADD] : 알림 조회 api 기능 연동 & 로그인 후 안읽은 알림 개수 즉시 적용 이슈 해결

### DIFF
--- a/src/api/alert.ts
+++ b/src/api/alert.ts
@@ -7,9 +7,7 @@ const Alert = {
   async v1GetAlertList(data: getAlertListType) {
     try {
       const url = `${prefix}`;
-      const result = await instanceWithToken.get(url, {
-        params: data,
-      });
+      const result = await instanceWithToken.post(url, data);
       return result;
     } catch (err) {
       return Promise.reject(err);
@@ -20,7 +18,7 @@ const Alert = {
     try {
       const url = `${prefix}`;
       const result = await instanceWithToken.delete(url, {
-        data: {
+        params: {
           alertId: id,
         },
       });

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useQuery } from "@tanstack/react-query";
 import { kakaoURL, useLogin } from "@/api/login";
 import TextButton from "@/components/common/TextButton";
 import TextField from "@/components/common/TextField";
@@ -20,6 +21,11 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+// recoil
+import { useSetRecoilState } from "recoil";
+import { alertUnReadCntState } from "@/recoil/alert/alertState";
+// api
+import Api from "@/api/alert";
 
 export default function Login() {
   const router = useRouter();
@@ -29,6 +35,21 @@ export default function Login() {
     email: "",
     password: "",
   });
+  const setUnReadAlertCnt = useSetRecoilState(alertUnReadCntState);
+
+  const { isLoading, error, data, refetch } = useQuery(
+    ["alertUnreadCnt"],
+    () => Api.v1GetUnReadCount(),
+    {
+      onSuccess: (res) => {
+        if (res.data.data) {
+          const { alertUnreadCount } = res.data.data;
+          setUnReadAlertCnt({ unReadCnt: alertUnreadCount });
+        }
+      },
+      enabled: false,
+    },
+  );
 
   const handleFormSubmit = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
@@ -41,6 +62,7 @@ export default function Login() {
           localStorage.setItem("accessToken", response.data.accessToken);
           localStorage.setItem("refreshToken", response.data.refreshToken);
           localStorage.setItem("userId", response.data.userId);
+          refetch();
           router.push("/");
         }
       },

--- a/src/components/chat/ChatRoomListAside.tsx
+++ b/src/components/chat/ChatRoomListAside.tsx
@@ -61,7 +61,7 @@ const ChatRoomListAside = () => {
   return (
     <ChatRoomListWrapper>
       <ChatRoomList>
-        {chatRooms.chatRoomList.length > 0 ? (
+        {chatRooms.chatRoomList?.length > 0 ? (
           chatRooms.chatRoomList.map((item, index) => {
             return (
               <ChatRoomItem

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -43,6 +43,7 @@ export default function Header() {
     if (userId) {
       await logout(userId);
       clearToken();
+      setIsAlertOpen(false);
       setIsLoggedIn(false);
       router.replace("/");
     }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -18,20 +18,17 @@ import { getUserId, clearToken } from "@/utils/tokenControl";
 import Image from "next/image";
 // socket
 import useSocket from "@/hooks/useSocket";
-// api
-import Api from "@/api/alert";
 // recoil
 import { useRecoilValue } from "recoil";
-import { socketAlertMsgState } from "@/recoil/socket/socketState";
+import { alertUnReadCntState } from "@/recoil/alert/alertState";
 
 export default function Header() {
   const path = usePathname();
   const router = useRouter();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState<boolean>(false);
-  const [unReadAlertCnt, setUnReadAlertCnt] = useState<number>(0);
   const [socketConnected, setSocketConnected] = useState<boolean>(false);
-  const socketAlertMsg = useRecoilValue(socketAlertMsgState);
+  const unReadAlertCnt = useRecoilValue(alertUnReadCntState);
   const [
     socketConnect,
     socketDisconnect,
@@ -40,20 +37,6 @@ export default function Header() {
   ] = useSocket();
   const ws = useRef<WebSocket | null>(null);
   const userId = typeof window !== "undefined" && getUserId();
-
-  const { isLoading, error, data, refetch } = useQuery(
-    ["alertList"],
-    () => Api.v1GetUnReadCount(),
-    {
-      refetchOnWindowFocus: true,
-      onSuccess: (res) => {
-        if (res.data.data) {
-          const { alertUnreadCount } = res.data.data;
-          setUnReadAlertCnt(alertUnreadCount);
-        }
-      },
-    },
-  );
 
   const handleLogout = async (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
@@ -80,10 +63,6 @@ export default function Header() {
       socketLogin();
     }
   }, [path]);
-
-  useEffect(() => {
-    refetch();
-  }, [socketAlertMsg]);
 
   useEffect(() => {
     if (socketConnected) {
@@ -129,7 +108,7 @@ export default function Header() {
               className="alert"
             >
               <Image src="/images/bell.svg" width={27} height={23} alt="알림" />
-              <AlertBadge>{unReadAlertCnt}</AlertBadge>
+              <AlertBadge>{unReadAlertCnt.unReadCnt}</AlertBadge>
             </MenuIconItem>
             <MenuItem
               href="#"

--- a/src/hooks/useSocket.tsx
+++ b/src/hooks/useSocket.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useQuery } from "@tanstack/react-query";
 import { MutableRefObject } from "react";
 import { getUserId } from "@/utils/tokenControl";
 import { useSetRecoilState } from "recoil";
@@ -8,6 +9,9 @@ import {
   socketCommentAddState,
   socketCommentDeleteState,
 } from "@/recoil/socket/socketState";
+import { alertUnReadCntState } from "@/recoil/alert/alertState";
+// api
+import Api from "@/api/alert";
 
 const webSocketUrl = `${process.env.NEXT_PUBLIC_SOCKET_BASE_URL}/api/chatting`;
 
@@ -16,6 +20,21 @@ const useSocket = () => {
   const setSocketDeleteComment = useSetRecoilState(socketCommentDeleteState);
   const setSocketAddChat = useSetRecoilState(socketChatAddState);
   const setSocketAlertMsg = useSetRecoilState(socketAlertMsgState);
+  const setUnReadAlertCnt = useSetRecoilState(alertUnReadCntState);
+
+  const { isLoading, error, data, refetch } = useQuery(
+    ["alertUnreadCnt"],
+    () => Api.v1GetUnReadCount(),
+    {
+      refetchOnWindowFocus: true,
+      onSuccess: (res) => {
+        if (res.data.data) {
+          const { alertUnreadCount } = res.data.data;
+          setUnReadAlertCnt({ unReadCnt: alertUnreadCount });
+        }
+      },
+    },
+  );
 
   const socketConnect = (
     ws: MutableRefObject<WebSocket | null>,
@@ -91,6 +110,8 @@ const useSocket = () => {
           alertId: data.alertId,
         });
       }
+
+      refetch();
     };
   };
 

--- a/src/recoil/alert/alertState.ts
+++ b/src/recoil/alert/alertState.ts
@@ -1,0 +1,11 @@
+import { atom } from "recoil";
+import { alertUnReadCntType } from "@/types/alert";
+
+const alertUnReadCntState = atom<alertUnReadCntType>({
+  key: "alertUnReadCntState",
+  default: {
+    unReadCnt: 0,
+  },
+});
+
+export { alertUnReadCntState };

--- a/src/styles/components/alert/Alert.tsx
+++ b/src/styles/components/alert/Alert.tsx
@@ -5,7 +5,7 @@ const AlertWrapper = styled.div`
   top: 4.5rem;
   right: 1rem;
   display: flex;
-  width: 22rem;
+  width: 30rem;
   flex-direction: column;
   background-color: #fff;
   box-shadow: 0 0 0.35rem rgba(0, 0, 0, 0.25);
@@ -101,7 +101,7 @@ const AlertItemTop = styled.div`
 const AlertItemBottom = styled.div`
   display: flex;
   justify-content: flex-end;
-  width: 15.5rem;
+  width: 24rem;
   font-size: 14px;
   font-weight: 600;
   color: #a9a9a9;
@@ -109,7 +109,7 @@ const AlertItemBottom = styled.div`
 
 const AlertItemText = styled.div`
   display: block;
-  width: 16rem;
+  width: 25.5rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/types/alert.ts
+++ b/src/types/alert.ts
@@ -10,5 +10,9 @@ export interface IAlertList {
   alertId: number;
   alertReadDateTime: Date;
   alertType: string;
-  checkStatue: boolean;
+  checkStatus: boolean;
+}
+
+export interface alertUnReadCntType {
+  unReadCnt: number;
 }


### PR DESCRIPTION
## 작업사항
- [x] 알림 조회 api 기능 연동
- [x] 로그인 후 안읽은 알림 개수 바로 적용 이슈 해결

## 비고
- 알림 삭제 시에 안읽은 알림 개수 반영 안되는 부분 있음 `error`

## Github 이슈
- [로그인 후 안읽은 알림 개수 바로 적용 이슈 해결](https://github.com/KangHayeonn/together-party-tonight-client/issues/101#issue-1832134370)
- [알림 기능 구현](https://github.com/KangHayeonn/together-party-tonight-client/issues/96#issue-1827736754)

## 작업일자
- 2023.08.02

<br>
