### PR TITLE
[ADD] : 리스트형 검색페이지 & 리스트형 검색 상세페이지 API 연동 및 기능 구현

### DIFF
--- a/src/components/common/DropDown.tsx
+++ b/src/components/common/DropDown.tsx
@@ -47,6 +47,10 @@ const DropDown = ({
   useEffect(() => {
     document.addEventListener("click", clickWrap);
     dropDownList ? setList(dropDownList) : setList(searchCategoryList);
+
+    return () => {
+      document.removeEventListener("click", clickWrap);
+    };
   }, [dropDownList]);
 
   return (

--- a/src/components/common/DropDown.tsx
+++ b/src/components/common/DropDown.tsx
@@ -51,7 +51,7 @@ const DropDown = ({
 
   return (
     <DropDownWrapper ref={menuWrap} {...props}>
-      <DropDownBtn>
+      <DropDownBtn type="button">
         {title}
         <Image
           src={`${!isOpen ? "/images/arrowDown.svg" : "/images/arrowUp.svg"}`}

--- a/src/components/common/RoundButton.tsx
+++ b/src/components/common/RoundButton.tsx
@@ -28,6 +28,7 @@ const RoundButton = ({
 
   return (
     <RoundBtnWrapper
+      type="button"
       className={`${btnActive && "active"}`}
       onClick={onClickEvent || onClickBtn}
       disabled={disabled}

--- a/src/components/common/TextButton.tsx
+++ b/src/components/common/TextButton.tsx
@@ -24,7 +24,7 @@ const TextButton = ({
   ...props
 }: ButtonProps) => {
   return (
-    <BtnWrapper onClick={onClick} disabled={disabled} {...props}>
+    <BtnWrapper type="button" onClick={onClick} disabled={disabled} {...props}>
       {text}
     </BtnWrapper>
   );

--- a/src/components/search/SearchTemplate.tsx
+++ b/src/components/search/SearchTemplate.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import React from "react";
-import { SearchPageWrapper } from "@/styles/components/search/SearchTemplate";
+import { useRouter, usePathname } from "next/navigation";
+import {
+  SearchPageWrapper,
+  SearchTypeBtn,
+} from "@/styles/components/search/SearchTemplate";
 
 interface SearchTemplateProps {
   children: React.ReactNode;
@@ -9,8 +13,17 @@ interface SearchTemplateProps {
 }
 
 const SearchTemplate = ({ children, classType }: SearchTemplateProps) => {
+  const router = useRouter();
+  const path = usePathname();
+  const searchType = path?.split("/").at(-1);
+
   return (
-    <SearchPageWrapper className={classType}>{children}</SearchPageWrapper>
+    <SearchPageWrapper className={classType}>
+      {children}
+      <SearchTypeBtn onClick={() => router.push("/search/list")}>
+        {searchType === "list" ? "맵으로 보기" : "리스트로 보기"}
+      </SearchTypeBtn>
+    </SearchPageWrapper>
   );
 };
 

--- a/src/components/search/SearchTemplate.tsx
+++ b/src/components/search/SearchTemplate.tsx
@@ -17,10 +17,16 @@ const SearchTemplate = ({ children, classType }: SearchTemplateProps) => {
   const path = usePathname();
   const searchType = path?.split("/").at(-1);
 
+  const changeSearchType = () => {
+    return searchType === "list"
+      ? router.push("/search")
+      : router.push("/search/list");
+  };
+
   return (
     <SearchPageWrapper className={classType}>
       {children}
-      <SearchTypeBtn onClick={() => router.push("/search/list")}>
+      <SearchTypeBtn onClick={() => changeSearchType()}>
         {searchType === "list" ? "맵으로 보기" : "리스트로 보기"}
       </SearchTypeBtn>
     </SearchPageWrapper>

--- a/src/components/search/listType/SearchCategory.tsx
+++ b/src/components/search/listType/SearchCategory.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import {
   SearchCategoryWrapper,
   SearchCategoryList,
@@ -8,21 +8,78 @@ import {
 } from "@/styles/components/search/listType/SearchCategory";
 import { searchCategoryList } from "@/utils/mock/search";
 
-const SearchCategory = () => {
+interface SearchCategoryProps {
+  categoryList?: Array<string>;
+  changeCategory?: (categoryArr: Array<string>) => void;
+}
+
+const SearchCategory = ({
+  categoryList,
+  changeCategory,
+}: SearchCategoryProps) => {
+  const [checkItems, setCheckItems] = useState<Array<string>>([]);
+
+  const handleCheck = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const item = e.target.value;
+    if (item === "모두") {
+      handleAllCheck(e.target.checked);
+      return;
+    }
+
+    const isCheck = e.target.checked;
+    if (isCheck) {
+      if (changeCategory) setCheckItems((items) => [...items, item]);
+    } else {
+      if (changeCategory)
+        setCheckItems((items) => {
+          if (items.length > 7) items.shift();
+          const tempArr = items.filter((el) => el !== item);
+          return tempArr;
+        });
+    }
+  };
+
+  const handleAllCheck = (check: boolean) => {
+    if (check) {
+      const tempArr: Array<string> = ["모두"];
+      searchCategoryList.forEach((item) => tempArr.push(item));
+      if (changeCategory) changeCategory(tempArr);
+      setCheckItems(tempArr);
+    } else {
+      if (changeCategory) changeCategory([]);
+    }
+  };
+
+  useEffect(() => {
+    if (changeCategory) changeCategory(checkItems);
+  }, [checkItems]);
+
   return (
     <SearchCategoryWrapper>
       <SearchCategoryList>
         <SearchCategoryItem>
-          <SearchCategoryItemInput type="checkbox" id="all" />
+          <SearchCategoryItemInput
+            type="checkbox"
+            id="all"
+            value="모두"
+            onChange={(e) => handleCheck(e)}
+            checked={checkItems.length > 7 ? true : false}
+          />
           <SearchCategoryItemLabel htmlFor="all" className="label-tag">
             전체보기
           </SearchCategoryItemLabel>
         </SearchCategoryItem>
-        {searchCategoryList &&
-          searchCategoryList.map((item, index) => {
+        {categoryList &&
+          categoryList.map((item, index) => {
             return (
               <SearchCategoryItem key={index}>
-                <SearchCategoryItemInput type="checkbox" id={item} />
+                <SearchCategoryItemInput
+                  type="checkbox"
+                  id={item}
+                  value={`${item}`}
+                  onChange={(e) => handleCheck(e)}
+                  checked={checkItems.includes(item) ? true : false}
+                />
                 <SearchCategoryItemLabel htmlFor={item} className="label-tag">
                   {item}
                 </SearchCategoryItemLabel>

--- a/src/components/search/listType/SearchFilter.tsx
+++ b/src/components/search/listType/SearchFilter.tsx
@@ -14,11 +14,35 @@ import SliderForm from "@/components/common/SliderForm";
 import SearchStatus from "@/components/search/mapType/SearchStatus";
 import SearchTagList from "@/components/search/mapType/SearchTagList";
 import RoundButton from "@/components/common/RoundButton";
-import { searchTagList } from "@/utils/mock/search";
+// recoil
+import { useRecoilState } from "recoil";
+import { searchOptionsState } from "@/recoil/search/searchState";
 
 const SearchFilter = () => {
+  const [searchOptions, setSearchOptions] = useRecoilState(searchOptionsState);
   const onClickRoundBtnEvent = () => {
     // TODO : search api logic
+  };
+
+  const onSearchDistanceChange = (distance: number) => {
+    setSearchOptions({
+      ...searchOptions,
+      distance: distance,
+    });
+  };
+
+  const onSearchStatusChange = (status: string) => {
+    setSearchOptions({
+      ...searchOptions,
+      status: status === "전체" ? "all" : "recruit",
+    });
+  };
+
+  const onSearchMaxNumChange = (maxNum: number) => {
+    setSearchOptions({
+      ...searchOptions,
+      memberNum: maxNum,
+    });
   };
 
   return (
@@ -34,6 +58,7 @@ const SearchFilter = () => {
                   minText="0km"
                   maxText="10km"
                   defaultValue={5}
+                  changeNum={onSearchDistanceChange}
                 />
               </SearchSliderWrapper>
             </SearchDataContent>
@@ -41,13 +66,21 @@ const SearchFilter = () => {
           <SearchTableRow>
             <SearchDataTitle>모집 상태</SearchDataTitle>
             <SearchDataContent>
-              <SearchStatus defaultValue="전체" />
+              <SearchStatus
+                defaultValue="전체"
+                changeStatusType={onSearchStatusChange}
+              />
             </SearchDataContent>
           </SearchTableRow>
           <SearchTableRow>
             <SearchDataTitle>모집 인원</SearchDataTitle>
             <SearchDataContent>
-              <NumberForm min={0} max={30} />
+              <NumberForm
+                min={0}
+                max={30}
+                defaultNum={10}
+                changeMax={onSearchMaxNumChange}
+              />
             </SearchDataContent>
           </SearchTableRow>
           <SearchTableRow>

--- a/src/components/search/listType/SearchFilter.tsx
+++ b/src/components/search/listType/SearchFilter.tsx
@@ -60,6 +60,8 @@ const SearchFilter = () => {
             <SearchOptionContent>
               <RoundButton
                 text="옵션 적용"
+                color="#fff"
+                background="#778da9"
                 onClickEvent={onClickRoundBtnEvent}
               />
             </SearchOptionContent>

--- a/src/components/search/listType/SearchItem.tsx
+++ b/src/components/search/listType/SearchItem.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useParams } from "next/navigation";
 import {
   SearchItemWrapper,
   SearchItemBox,
@@ -9,15 +11,59 @@ import SearchItemSummary from "@/components/search/listType/SearchItemSummary";
 import SearchItemDetail from "@/components/search/listType/SearchItemDetail";
 import SearchItemBtn from "@/components/search/listType/SearchItemBtn";
 import SearchItemComment from "@/components/search/listType/SearchItemComment";
+// api
+import Api from "@/api/club";
+// recoil
+import { useSetRecoilState } from "recoil";
+import { clubDetailState } from "@/recoil/club/clubState";
 
 const SearchItem = () => {
+  const params = useParams();
+  const { id } = params;
+  const setClubDetail = useSetRecoilState(clubDetailState);
+
+  const { isLoading, error, data } = useQuery(
+    ["searchClubDetailByMap"],
+    async () => {
+      const response = await Api.v1FetchClubDetail(Number(id));
+      return response;
+    },
+    {
+      refetchOnWindowFocus: true,
+      // enabled: false,
+      onSuccess: (res) => {
+        const { data } = res.data;
+        setClubDetail({
+          address: data.address,
+          clubCategory: data.clubCategory,
+          clubContent: data.clubContent,
+          clubMaximum: data.clubMaximum,
+          clubName: data.clubName,
+          clubTags: [...data.clubTags],
+          createdDate: data.createdDate,
+          image: data.image,
+          isRecruit: data.isRecruit,
+          latitude: data.latitude,
+          longitude: data.longitude,
+          meetingDate: data.meetingDate,
+          memberCount: data.memberCount,
+          memberId: data.memberId,
+          modifiedDate: data.modifiedDate,
+          nickName: data.nickName,
+          ratingAvg: data.ratingAvg,
+          reviewCnt: data.reviewCnt,
+        });
+      },
+    },
+  );
+
   return (
     <SearchItemWrapper>
       <SearchItemBox>
         <SearchItemSummary />
         <SearchItemDetail />
-        <SearchItemBtn />
-        <SearchItemComment />
+        <SearchItemBtn clubId={Number(id)} />
+        <SearchItemComment clubId={Number(id)} />
       </SearchItemBox>
     </SearchItemWrapper>
   );

--- a/src/components/search/listType/SearchItemBtn.tsx
+++ b/src/components/search/listType/SearchItemBtn.tsx
@@ -1,14 +1,41 @@
-import React from "react";
+import React, { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
 import {
   SearchItemBtnWrapper,
   SearchItemBtnBox,
 } from "@/styles/components/search/listType/SearchItemBtn";
 import TextButton from "@/components/common/TextButton";
 import { SearchItemCommentProps } from "../mapType/SearchItemComment";
+import { getUserId } from "@/utils/tokenControl";
+import ConfirmModal from "@/components/common/modal/ConfirmModal";
+// api
+import Api from "@/api/club";
+// recoil
+import { useRecoilValue } from "recoil";
+import { clubDetailState } from "@/recoil/club/clubState";
 
 const SearchItemBtn = ({ clubId }: SearchItemCommentProps) => {
+  const userId = typeof window !== "undefined" && Number(getUserId());
+  const clubDetail = useRecoilValue(clubDetailState);
+  const [isOpenModal, setIsOpenModal] = useState<boolean>(false);
+
+  const { mutate: signupClub } = useMutation({
+    mutationFn: () => Api.v1SignupClub(clubId),
+    onSuccess: (res) => {
+      // TODO : signup club success
+      const { code } = res.data;
+      if (code === 200) console.log("신청하기 완료");
+      // errorMessage : 권한이 없습니다
+    },
+  });
+
+  const handleOpenModal = () => {
+    document.body.style.overflow = "hidden";
+    setIsOpenModal(true);
+  };
+
   const onClickClubApply = () => {
-    // TODO : club apply api logic
+    signupClub();
   };
 
   const onClickChat = () => {
@@ -18,27 +45,39 @@ const SearchItemBtn = ({ clubId }: SearchItemCommentProps) => {
   return (
     <SearchItemBtnWrapper>
       <SearchItemBtnBox>
-        <TextButton
-          text="신청하기"
-          onClick={onClickClubApply}
-          fontSize={18}
-          background="#778da9"
-          color="#fff"
-          weight={600}
-          width={140}
-          height={40}
-        />
-        <TextButton
-          text="채팅하기"
-          onClick={onClickChat}
-          fontSize={18}
-          background="#778da9"
-          color="#fff"
-          weight={600}
-          width={140}
-          height={40}
-        />
+        {clubDetail.memberId !== userId && clubDetail.isRecruit && (
+          <TextButton
+            text="신청하기"
+            onClick={() => handleOpenModal()}
+            fontSize={18}
+            background="#778da9"
+            color="#fff"
+            weight={600}
+            width={140}
+            height={40}
+          />
+        )}
+        {clubDetail.memberId !== userId && (
+          <TextButton
+            text="채팅하기"
+            onClick={onClickChat}
+            fontSize={18}
+            background="#778da9"
+            color="#fff"
+            weight={600}
+            width={140}
+            height={40}
+          />
+        )}
       </SearchItemBtnBox>
+      {isOpenModal && (
+        <ConfirmModal
+          modalTitle="모임을 신청하시겠습니까?"
+          modalText="모임 신청 후 모임장의 응답을 기다려야합니다."
+          onClose={setIsOpenModal}
+          handleSubmit={onClickClubApply}
+        />
+      )}
     </SearchItemBtnWrapper>
   );
 };

--- a/src/components/search/listType/SearchItemBtn.tsx
+++ b/src/components/search/listType/SearchItemBtn.tsx
@@ -4,8 +4,9 @@ import {
   SearchItemBtnBox,
 } from "@/styles/components/search/listType/SearchItemBtn";
 import TextButton from "@/components/common/TextButton";
+import { SearchItemCommentProps } from "../mapType/SearchItemComment";
 
-const SearchItemBtn = () => {
+const SearchItemBtn = ({ clubId }: SearchItemCommentProps) => {
   const onClickClubApply = () => {
     // TODO : club apply api logic
   };

--- a/src/components/search/listType/SearchItemComment.tsx
+++ b/src/components/search/listType/SearchItemComment.tsx
@@ -15,8 +15,9 @@ import {
 import TextField from "@/components/common/TextField";
 import TextButton from "@/components/common/TextButton";
 import { commentList } from "@/utils/mock/search";
+import { SearchItemCommentProps } from "../mapType/SearchItemComment";
 
-const SearchItemComment = () => {
+const SearchItemComment = ({ clubId }: SearchItemCommentProps) => {
   const [message, setMessage] = useState<string>("");
 
   const onChangeMessage = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/search/listType/SearchItemComment.tsx
+++ b/src/components/search/listType/SearchItemComment.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import { useQuery, useMutation } from "@tanstack/react-query";
 import {
   SearchCommentWrapper,
   SearchCommentTitle,
@@ -11,22 +12,129 @@ import {
   SearchCommentText,
   SearchComment,
   SearchCommentBtn,
+  SearchResultEmpty,
+  SearchLoadingWrapper,
 } from "@/styles/components/search/listType/SearchItemComment";
 import TextField from "@/components/common/TextField";
 import TextButton from "@/components/common/TextButton";
-import { commentList } from "@/utils/mock/search";
+import Loading from "@/components/common/Loading";
 import { SearchItemCommentProps } from "../mapType/SearchItemComment";
+import { getUserId } from "@/utils/tokenControl";
+import { CommentType } from "@/types/comment";
+import { elapsedTime } from "@/utils/dateFormat";
+import ConfirmModal from "@/components/common/modal/ConfirmModal";
+// api
+import Api from "@/api/comment";
+// recoil
+import { useRecoilValue } from "recoil";
+import {
+  socketCommentAddState,
+  socketCommentDeleteState,
+} from "@/recoil/socket/socketState";
 
 const SearchItemComment = ({ clubId }: SearchItemCommentProps) => {
+  const socketComment = useRecoilValue(socketCommentAddState);
+  const socketDeleteComment = useRecoilValue(socketCommentDeleteState);
   const [message, setMessage] = useState<string>("");
+  const [commentList, setCommentList] = useState<Array<CommentType>>([]);
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
+  const [isOpenModal, setIsOpenModal] = useState<boolean>(false);
+  const [commentId, setCommentId] = useState<number>(-1);
+  const memberId = Number(
+    (typeof window !== "undefined" && Number(getUserId())) || -1,
+  );
 
   const onChangeMessage = (e: React.ChangeEvent<HTMLInputElement>) => {
     setMessage(e.target.value);
   };
 
-  const onClickEvent = () => {
-    // TODO : comment add api logic
+  const handleOpenModal = () => {
+    document.body.style.overflow = "hidden";
+    setIsOpenModal(true);
   };
+
+  const { data, isLoading } = useQuery(
+    ["commentList"],
+    () => Api.v1GetComment(clubId),
+    {
+      refetchOnWindowFocus: true,
+      onSuccess: (res) => {
+        if (res.data.data) {
+          const comments = res.data.data;
+          setCommentList(comments);
+        }
+      },
+    },
+  );
+
+  const { mutate: addComment } = useMutation({
+    mutationFn: () =>
+      Api.v1AddComment({
+        clubId: clubId,
+        commentContent: message,
+      }),
+  });
+
+  const { mutate: deleteComment } = useMutation({
+    mutationFn: (commentId: number) => Api.v1DeleteComment(commentId),
+  });
+
+  const onClickEvent = async () => {
+    if (!isLoggedIn) {
+      alert("댓글은 로그인 후 등록 가능합니다.");
+      return;
+    }
+    await addComment();
+    setMessage("");
+  };
+
+  const onClickDelete = (commentId: number) => {
+    setCommentId(commentId);
+    handleOpenModal();
+  };
+
+  useEffect(() => {
+    if (memberId > 0) {
+      setIsLoggedIn(true);
+    }
+
+    return () => {
+      Api.v1LeaveComment(clubId);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (socketComment.method === "CREATE") {
+      setCommentList((comments) => [
+        ...comments,
+        {
+          commentId: socketComment.commentId,
+          memberId: socketComment.memberId,
+          nickName: socketComment.nickName,
+          clubId: clubId,
+          comment: socketComment.comment,
+          createdDate: socketComment.createdDate,
+          modifiedDate: socketComment.modifiedDate,
+        },
+      ]);
+    }
+
+    if (socketDeleteComment.method === "DELETE") {
+      setCommentList((comments) =>
+        comments.filter(
+          (item) => item.commentId !== socketDeleteComment.commentId,
+        ),
+      );
+    }
+  }, [socketComment, socketDeleteComment]);
+
+  if (isLoading || !data) {
+    return (
+      <SearchLoadingWrapper>
+        <Loading />
+      </SearchLoadingWrapper>
+    );
+  }
 
   return (
     <SearchCommentWrapper>
@@ -36,6 +144,7 @@ const SearchItemComment = ({ clubId }: SearchItemCommentProps) => {
           <TextField
             message={message}
             onChangeText={onChangeMessage}
+            handleEvent={onClickEvent}
             height={2.2}
             fontSize={0.92}
             placeholder="댓글을 달아보세요"
@@ -53,42 +162,51 @@ const SearchItemComment = ({ clubId }: SearchItemCommentProps) => {
         />
       </SearchCommentInputForm>
       <SearchCommentList>
-        {commentList.map((item, index) => {
-          return (
-            <SearchCommentItem key={index}>
-              <SearchCommentTop>
-                <SearchCommentText>{item.nickName}</SearchCommentText>
-                <SearchCommentText>{item.updatedDate}</SearchCommentText>
-              </SearchCommentTop>
-              <SearchCommentBottom>
-                <SearchComment>{item.comment}</SearchComment>
-                <SearchCommentBtn>
-                  <TextButton
-                    text="삭제"
-                    onClick={onClickEvent}
-                    fontSize={13}
-                    background="#778DA9"
-                    color="#fff"
-                    weight={500}
-                    width={75}
-                    height={25}
-                  />
-                  <TextButton
-                    text="답글달기"
-                    onClick={onClickEvent}
-                    fontSize={13}
-                    background="#0D3471"
-                    color="#fff"
-                    weight={500}
-                    width={75}
-                    height={25}
-                  />
-                </SearchCommentBtn>
-              </SearchCommentBottom>
-            </SearchCommentItem>
-          );
-        })}
+        {commentList.length > 0 ? (
+          commentList.map((item, index) => {
+            return (
+              <SearchCommentItem key={index}>
+                <SearchCommentTop>
+                  <SearchCommentText>{item.nickName}</SearchCommentText>
+                  <SearchCommentText>
+                    {" "}
+                    {elapsedTime(item.modifiedDate)}
+                  </SearchCommentText>
+                </SearchCommentTop>
+                <SearchCommentBottom>
+                  <SearchComment>{item.comment}</SearchComment>
+                  <SearchCommentBtn>
+                    {item.memberId === memberId && (
+                      <SearchCommentBtn>
+                        <TextButton
+                          text="삭제"
+                          onClick={() => onClickDelete(item.commentId)}
+                          fontSize={13}
+                          background="#0D3471"
+                          color="#fff"
+                          weight={500}
+                          width={75}
+                          height={25}
+                        />
+                      </SearchCommentBtn>
+                    )}
+                  </SearchCommentBtn>
+                </SearchCommentBottom>
+              </SearchCommentItem>
+            );
+          })
+        ) : (
+          <SearchResultEmpty>검색 결과가 없습니다</SearchResultEmpty>
+        )}
       </SearchCommentList>
+      {isOpenModal && (
+        <ConfirmModal
+          modalTitle="댓글을 삭제하시겠습니까?"
+          modalText="댓글을 삭제하면 작성 기록이 사라집니다."
+          onClose={setIsOpenModal}
+          handleSubmit={() => deleteComment(commentId)}
+        />
+      )}
     </SearchCommentWrapper>
   );
 };

--- a/src/components/search/listType/SearchItemDetail.tsx
+++ b/src/components/search/listType/SearchItemDetail.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   SearchItemDetailWrapper,
   SearchItemDetailContent,
@@ -9,12 +9,15 @@ import SearchItemTagList from "@/components/search/listType/SearchItemTagList";
 import TextButton from "@/components/common/TextButton";
 import { useRecoilValue } from "recoil";
 import { clubDetailState } from "@/recoil/club/clubState";
+import KakaoModal from "../map/KakaoMapModal";
 
 const SearchItemDetail = () => {
   const clubDetail = useRecoilValue(clubDetailState);
+  const [isOpenModal, setIsOpenModal] = useState<boolean>(false);
 
   const onClickEvent = () => {
-    // TODO : kakao map modal open logic
+    document.body.style.overflow = "hidden";
+    setIsOpenModal(true);
   };
 
   return (
@@ -40,6 +43,9 @@ const SearchItemDetail = () => {
           height={33}
         />
       </SearchItemDetailBottom>
+      {isOpenModal && (
+        <KakaoModal modalTitle={clubDetail.clubName} onClose={setIsOpenModal} />
+      )}
     </SearchItemDetailWrapper>
   );
 };

--- a/src/components/search/listType/SearchItemDetail.tsx
+++ b/src/components/search/listType/SearchItemDetail.tsx
@@ -7,9 +7,12 @@ import {
 } from "@/styles/components/search/listType/SearchItemDetail";
 import SearchItemTagList from "@/components/search/listType/SearchItemTagList";
 import TextButton from "@/components/common/TextButton";
-import { searchTagList } from "@/utils/mock/search";
+import { useRecoilValue } from "recoil";
+import { clubDetailState } from "@/recoil/club/clubState";
 
 const SearchItemDetail = () => {
+  const clubDetail = useRecoilValue(clubDetailState);
+
   const onClickEvent = () => {
     // TODO : kakao map modal open logic
   };
@@ -17,11 +20,13 @@ const SearchItemDetail = () => {
   return (
     <SearchItemDetailWrapper>
       <SearchItemDetailContent>
-        초보여도 괜찮습니다.
-        <br /> 일주일에 2번정도 목동 테니스장에서 저녁시간에 치실 분 구해요.
+        {clubDetail.clubContent}
       </SearchItemDetailContent>
       <SearchItemDetailTagWrapper>
-        <SearchItemTagList tagList={searchTagList} classType="secondary" />
+        <SearchItemTagList
+          tagList={clubDetail.clubTags}
+          classType="secondary"
+        />
       </SearchItemDetailTagWrapper>
       <SearchItemDetailBottom>
         <TextButton

--- a/src/components/search/listType/SearchItemSummary.tsx
+++ b/src/components/search/listType/SearchItemSummary.tsx
@@ -8,18 +8,24 @@ import {
   SearchItemSummaryBox,
   SearchItemSummaryText,
 } from "@/styles/components/search/listType/SearchItemSummary";
+import { useRecoilValue } from "recoil";
+import { clubDetailState } from "@/recoil/club/clubState";
+import { getDateFormat, getTimeFormat } from "@/utils/dateFormat";
+import { elapsedTime } from "@/utils/dateFormat";
 
 const SearchItemSummary = () => {
+  const clubDetail = useRecoilValue(clubDetailState);
+
   return (
     <SearchItemSummaryWrapper>
       <SearchItemSummaryLeft>
-        <SearchItemSummaryTitle>테니스 같이 치실 분</SearchItemSummaryTitle>
+        <SearchItemSummaryTitle>{clubDetail.clubName}</SearchItemSummaryTitle>
         <SearchItemSummaryBox>
           <SearchItemSummaryText className="detail">
-            23.06.05 15:33
+            {`${elapsedTime(new Date(clubDetail.modifiedDate))}`}
           </SearchItemSummaryText>
           <SearchItemSummaryText className="detail">
-            lydia
+            {clubDetail.nickName}
           </SearchItemSummaryText>
         </SearchItemSummaryBox>
       </SearchItemSummaryLeft>
@@ -31,14 +37,16 @@ const SearchItemSummary = () => {
             height={20}
             alt="Star Icon"
           />
-          <SearchItemSummaryText className="rating">4.5</SearchItemSummaryText>
+          <SearchItemSummaryText className="rating">
+            {clubDetail.ratingAvg.toFixed(1)}
+          </SearchItemSummaryText>
           <SearchItemSummaryText className="review">
-            리뷰 14
+            리뷰 {clubDetail.reviewCnt}
           </SearchItemSummaryText>
         </SearchItemSummaryBox>
         <SearchItemSummaryBox>
           <SearchItemSummaryText className="status">
-            모집중
+            {clubDetail.isRecruit ? "모집중" : "모집완료"}
           </SearchItemSummaryText>
           <Image
             src="/images/user.svg"
@@ -46,7 +54,9 @@ const SearchItemSummary = () => {
             height={21}
             alt="User Icon"
           />
-          <SearchItemSummaryText className="recruit">1/4</SearchItemSummaryText>
+          <SearchItemSummaryText className="recruit">
+            {clubDetail.memberCount}/{clubDetail.clubMaximum}
+          </SearchItemSummaryText>
         </SearchItemSummaryBox>
         <SearchItemSummaryBox>
           <Image
@@ -56,7 +66,11 @@ const SearchItemSummary = () => {
             alt="Clock Icon"
             className="clock"
           />
-          <SearchItemSummaryText>2023/06/06 오전 10:00</SearchItemSummaryText>
+          <SearchItemSummaryText>
+            {`${getDateFormat(
+              new Date(clubDetail.meetingDate),
+            )} ${getTimeFormat(new Date(clubDetail.meetingDate))}`}
+          </SearchItemSummaryText>
         </SearchItemSummaryBox>
       </SearchItemSummaryRight>
     </SearchItemSummaryWrapper>

--- a/src/components/search/listType/SearchItemTagList.tsx
+++ b/src/components/search/listType/SearchItemTagList.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useCallback } from "react";
 import {
   SearchTagListWrapper,
   SearchTagItem,
-  SearchTagItemInput,
   SearchTagItemLabel,
 } from "@/styles/components/search/listType/SearchTagList";
 
@@ -13,7 +12,6 @@ interface SearchItemTagList {
 
 const SearchItemTagList = ({ tagList, classType }: SearchItemTagList) => {
   const [newTagList, setNewTagList] = useState<Array<string>>([]);
-  const [openMore, setOpenMore] = useState<boolean>(false);
 
   const onCloseItems = useCallback(() => {
     const tempList = tagList?.filter((item, index) => index < 7);
@@ -30,24 +28,12 @@ const SearchItemTagList = ({ tagList, classType }: SearchItemTagList) => {
         newTagList.map((item, index) => {
           return (
             <SearchTagItem key={index}>
-              <SearchTagItemInput type="checkbox" id={item} value={item} />
-              <SearchTagItemLabel
-                htmlFor={item}
-                className={`label-tag ${classType}`}
-              >
+              <SearchTagItemLabel className={`label-tag ${classType}`}>
                 #{item}
               </SearchTagItemLabel>
             </SearchTagItem>
           );
         })}
-      {tagList?.length > 7 ? (
-        <SearchTagItem>
-          <SearchTagItemInput type="checkbox" id="more" value="more" />
-          <SearchTagItemLabel htmlFor="more" className={` ${classType}`}>
-            ···
-          </SearchTagItemLabel>
-        </SearchTagItem>
-      ) : null}
     </SearchTagListWrapper>
   );
 };

--- a/src/components/search/listType/SearchList.tsx
+++ b/src/components/search/listType/SearchList.tsx
@@ -18,14 +18,32 @@ import {
 import DropDown from "@/components/common/DropDown";
 import SearchItemTagList from "@/components/search/listType/SearchItemTagList";
 import { clubList } from "@/utils/mock/search";
+// recoil
+import { useRecoilState, useSetRecoilState } from "recoil";
+import { searchOptionsState } from "@/recoil/search/searchState";
 
 const SearchList = () => {
+  const [searchOptions, setSearchOptions] = useRecoilState(searchOptionsState);
+  const optionList = ["최신순", "인기순"];
+
+  const onSearchCategoryChange = (category: string) => {
+    const categoryId = category === "최신순" ? "latest" : "popular";
+    setSearchOptions({
+      ...searchOptions,
+      sortFilter: categoryId,
+    });
+  };
+
   return (
     <SearchListWrapper>
       <SearchListBox>
         <SearchListBoxTop>
           <SearchListTitle>총 {clubList.length}건</SearchListTitle>
-          <DropDown />
+          <DropDown
+            defaultText="최신순"
+            dropDownList={optionList}
+            changeText={onSearchCategoryChange}
+          />
         </SearchListBoxTop>
         <SearchListBoxBottom>
           {clubList &&

--- a/src/components/search/listType/SearchList.tsx
+++ b/src/components/search/listType/SearchList.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import {
   SearchListWrapper,
   SearchListBox,
@@ -14,16 +15,24 @@ import {
   SearchListItemContent,
   SearchListItemTag,
   SearchListItemBottom,
+  SearchResultEmpty,
 } from "@/styles/components/search/listType/SearchList";
 import DropDown from "@/components/common/DropDown";
 import SearchItemTagList from "@/components/search/listType/SearchItemTagList";
-import { clubList } from "@/utils/mock/search";
+import { categoryToKorMap } from "@/utils/categoryFormat";
+import { elapsedTime } from "@/utils/dateFormat";
 // recoil
-import { useRecoilState, useSetRecoilState } from "recoil";
-import { searchOptionsState } from "@/recoil/search/searchState";
+import { useRecoilState, useRecoilValue } from "recoil";
+import {
+  searchOptionsState,
+  searchResponseState,
+} from "@/recoil/search/searchState";
 
 const SearchList = () => {
+  const router = useRouter();
   const [searchOptions, setSearchOptions] = useRecoilState(searchOptionsState);
+  const searchResponse = useRecoilValue(searchResponseState);
+
   const optionList = ["최신순", "인기순"];
 
   const onSearchCategoryChange = (category: string) => {
@@ -38,7 +47,9 @@ const SearchList = () => {
     <SearchListWrapper>
       <SearchListBox>
         <SearchListBoxTop>
-          <SearchListTitle>총 {clubList.length}건</SearchListTitle>
+          <SearchListTitle>
+            총 {searchResponse.clubList.length}건
+          </SearchListTitle>
           <DropDown
             defaultText="최신순"
             dropDownList={optionList}
@@ -46,14 +57,17 @@ const SearchList = () => {
           />
         </SearchListBoxTop>
         <SearchListBoxBottom>
-          {clubList &&
-            clubList.map((item, index) => {
+          {searchResponse.clubList.length > 0 ? (
+            searchResponse.clubList.map((item, index) => {
               return (
-                <SearchListItem key={index}>
+                <SearchListItem
+                  key={index}
+                  onClick={() => router.push(`/search/list/${item.clubId}`)}
+                >
                   <SearchListItemTop>
                     <SearchItemLeft>
                       <SearchItemText className="category">
-                        {item.clubCategory}
+                        {categoryToKorMap.get(item.clubCategory)}
                       </SearchItemText>
                       <SearchItemText className="title">
                         {item.clubName}
@@ -67,7 +81,7 @@ const SearchList = () => {
                         alt="평점"
                       />
                       <SearchItemText className="review">
-                        {item.ratingAvg} 리뷰 {item.reviewCnt}
+                        {item.ratingAvg.toFixed(1)} 리뷰 {item.reviewCnt}
                       </SearchItemText>
                     </SearchItemRight>
                   </SearchListItemTop>
@@ -83,15 +97,19 @@ const SearchList = () => {
                   <SearchListItemBottom>
                     <SearchItemLeft>
                       <SearchItemText className="nick-name">
-                        lydia
+                        {item.nickName}
                       </SearchItemText>
-                      <SearchItemText className="date">5분전</SearchItemText>
+                      <SearchItemText className="date">
+                        {elapsedTime(item.modifiedDate || new Date())}
+                      </SearchItemText>
                       <SearchItemText className="address">
                         {item.address}
                       </SearchItemText>
                     </SearchItemLeft>
                     <SearchItemRight>
-                      <SearchItemText className="status">모집중</SearchItemText>
+                      <SearchItemText className="status">
+                        {item.isRecruit ? "모집중" : "모집완료"}
+                      </SearchItemText>
                       <SearchItemText>
                         <Image
                           src="/images/user.svg"
@@ -100,12 +118,17 @@ const SearchList = () => {
                           alt="User Icon"
                         />
                       </SearchItemText>
-                      <SearchItemText className="status">1/4</SearchItemText>
+                      <SearchItemText className="status">
+                        {item.memberCount}/{item.clubMaximum}
+                      </SearchItemText>
                     </SearchItemRight>
                   </SearchListItemBottom>
                 </SearchListItem>
               );
-            })}
+            })
+          ) : (
+            <SearchResultEmpty>검색 결과가 없습니다</SearchResultEmpty>
+          )}
         </SearchListBoxBottom>
       </SearchListBox>
     </SearchListWrapper>

--- a/src/components/search/listType/SearchNav.tsx
+++ b/src/components/search/listType/SearchNav.tsx
@@ -1,18 +1,115 @@
 "use client";
 
-import React from "react";
+import React, { useState, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
 import SearchForm from "@/components/common/SearchForm";
 import SearchCategory from "@/components/search/listType/SearchCategory";
 import {
   SearchNavWrapper,
   SearchFormWrapper,
 } from "@/styles/components/search/listType/SearchNav";
+import Api from "@/api/search";
+import { SearchPreview } from "@/components/common/SearchForm";
+import { validationSearchByAddress } from "@/utils/func/SearchFunc";
+import { useRecoilState, useSetRecoilState } from "recoil";
+import {
+  searchKeywordState,
+  searchState,
+  searchOptionsState,
+  searchResponseState,
+} from "@/recoil/search/searchState";
 
 const SearchNav = () => {
+  const [searchKeyword, setSearchKeyword] = useRecoilState(searchKeywordState);
+  const [previewList, setPreviewList] = useState<Array<SearchPreview>>([]);
+  const [searchAddress, setSearchAddress] = useRecoilState(searchState);
+  const [searchOptions, setSearchOptions] = useRecoilState(searchOptionsState);
+  const setSearchResponse = useSetRecoilState(searchResponseState);
+
+  const { isLoading, error, data } = useQuery(
+    ["searchAddress", searchKeyword],
+    () => Api.v1SearchAddress({ address: searchKeyword }),
+    {
+      refetchOnWindowFocus: true,
+      enabled: !!searchKeyword, // 특정 조건일 경우에만 useQuery 실행
+    },
+  );
+
+  const { refetch } = useQuery(
+    ["searchByAddress"],
+    async () => {
+      const options = {
+        lat: searchOptions.lat,
+        lng: searchOptions.lng,
+        page: searchOptions.page,
+      };
+      const response = await Api.v1SearchByAddress(options);
+      return response;
+    },
+    {
+      enabled: false,
+      onSuccess: (res) => {
+        const { clubList, count, totalCount } = res.data.data;
+        setSearchResponse({
+          clubList: [...clubList],
+          count: count,
+          totalCount: totalCount,
+        });
+      },
+    },
+  );
+
+  const onClickSearchBtn = () => {
+    if (validationSearchByAddress(searchOptions)) {
+      refetch();
+      initSearchOptions();
+    }
+  };
+
+  const initSearchOptions = () => {
+    setSearchOptions({
+      category: "",
+      distance: 5,
+      lat: 0,
+      lng: 0,
+      memberNum: 10,
+      page: 0,
+      size: 20,
+      sortFilter: "latest",
+      status: "all",
+      tags: "",
+    });
+    setSearchAddress({
+      ...searchAddress,
+      address_name: "",
+    });
+    setSearchKeyword("");
+  };
+
+  useEffect(() => {
+    setPreviewList(data?.data.documents);
+  }, [data]);
+
+  useEffect(() => {
+    setSearchOptions({
+      ...searchOptions,
+      lat: parseFloat(searchAddress.y),
+      lng: parseFloat(searchAddress.x),
+    });
+  }, [searchAddress]);
+
+  useEffect(() => {
+    initSearchOptions();
+  }, []);
+
   return (
     <SearchNavWrapper>
       <SearchFormWrapper>
-        <SearchForm />
+        <SearchForm
+          search={searchKeyword}
+          searchPreviewList={previewList}
+          searchByAddress={onClickSearchBtn}
+        />
       </SearchFormWrapper>
       <SearchCategory />
     </SearchNavWrapper>

--- a/src/components/search/listType/SearchNav.tsx
+++ b/src/components/search/listType/SearchNav.tsx
@@ -11,6 +11,7 @@ import {
 import Api from "@/api/search";
 import { SearchPreview } from "@/components/common/SearchForm";
 import { validationSearchByAddress } from "@/utils/func/SearchFunc";
+import { searchCategoryList } from "@/utils/mock/search";
 import { useRecoilState, useSetRecoilState } from "recoil";
 import {
   searchKeywordState,
@@ -86,6 +87,13 @@ const SearchNav = () => {
     setSearchKeyword("");
   };
 
+  const onSearchCategoryChange = (categoryArr: Array<string>) => {
+    setSearchOptions({
+      ...searchOptions,
+      category: categoryArr.length > 7 ? "모두" : categoryArr.toString(),
+    });
+  };
+
   useEffect(() => {
     setPreviewList(data?.data.documents);
   }, [data]);
@@ -111,7 +119,10 @@ const SearchNav = () => {
           searchByAddress={onClickSearchBtn}
         />
       </SearchFormWrapper>
-      <SearchCategory />
+      <SearchCategory
+        categoryList={searchCategoryList}
+        changeCategory={onSearchCategoryChange}
+      />
     </SearchNavWrapper>
   );
 };

--- a/src/components/search/map/KakaoMapModal.tsx
+++ b/src/components/search/map/KakaoMapModal.tsx
@@ -1,0 +1,26 @@
+import React, { Dispatch, SetStateAction } from "react";
+import ModalForm from "@/components/common/modal/ModalForm";
+import { ModalFormWrapper } from "@/styles/components/search/map/KakaoModal";
+import KakaoMap from "./KakaoMapSingle";
+
+interface KakaoModalProps {
+  modalTitle: string;
+  onClose: Dispatch<SetStateAction<boolean>>;
+}
+
+const KakaoModal = ({ modalTitle, onClose }: KakaoModalProps) => {
+  const onClickClose = () => {
+    document.body.style.overflow = "unset";
+    onClose(false);
+  };
+
+  return (
+    <ModalForm title={modalTitle} onClickEvent={onClickClose}>
+      <ModalFormWrapper>
+        <KakaoMap />
+      </ModalFormWrapper>
+    </ModalForm>
+  );
+};
+
+export default KakaoModal;

--- a/src/components/search/map/KakaoMapSingle.tsx
+++ b/src/components/search/map/KakaoMapSingle.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import Script from "next/script";
 import { Map, MapMarker, useMap, CustomOverlayMap } from "react-kakao-maps-sdk";
 import {
   MapWrapper,
@@ -72,9 +71,31 @@ const KakaoMap = () => {
     setAddressY(clubDetail.latitude);
   }, [clubDetail]);
 
+  const [mapLoaded, setMapLoaded] = useState<boolean>(false);
+
+  useEffect(() => {
+    // Kakao Maps SDK 로드 시작
+    const script = document.createElement("script");
+    script.src = KAKAO_SDK_URL;
+    script.async = true;
+    script.onload = () => {
+      // 스크립트 로드 완료 시점에서 Kakao Maps SDK 초기화
+      setMapLoaded(true);
+    };
+    document.head.appendChild(script);
+
+    // 컴포넌트 언마운트 시 스크립트를 제거
+    return () => {
+      document.head.removeChild(script);
+    };
+  }, []);
+
+  if (!mapLoaded) {
+    return <div>Loading...</div>;
+  }
+
   return (
     <>
-      <Script src={KAKAO_SDK_URL} strategy="beforeInteractive" />
       <MapWrapper>
         <Map
           center={{

--- a/src/components/search/mapType/SearchFilter.tsx
+++ b/src/components/search/mapType/SearchFilter.tsx
@@ -26,7 +26,6 @@ const SearchFilter = () => {
   };
 
   const onSearchCategoryChange = (categoryArr: Array<string>) => {
-    // category change
     setSearchOptions({
       ...searchOptions,
       category: categoryArr.length > 7 ? "모두" : categoryArr.toString(),

--- a/src/components/search/mapType/SearchItemComment.tsx
+++ b/src/components/search/mapType/SearchItemComment.tsx
@@ -30,7 +30,7 @@ import {
   socketCommentDeleteState,
 } from "@/recoil/socket/socketState";
 
-interface SearchItemCommentProps {
+export interface SearchItemCommentProps {
   clubId: number;
 }
 

--- a/src/components/search/mapType/SearchItemSummary.tsx
+++ b/src/components/search/mapType/SearchItemSummary.tsx
@@ -38,6 +38,7 @@ const SearchItemSummary = ({ clubId }: SearchItemSummaryProps) => {
       // TODO : signup club success
       const { code } = res.data;
       if (code === 200) console.log("신청하기 완료");
+      // errorMessage : 권한이 없습니다
     },
   });
 

--- a/src/components/search/mapType/SearchTagList.tsx
+++ b/src/components/search/mapType/SearchTagList.tsx
@@ -67,14 +67,17 @@ const SearchTagList = () => {
       {newTagList &&
         newTagList.map((item, index) => {
           return (
-            <SearchTagItem key={`tag${index}`}>
+            <SearchTagItem key={`tags${index}`}>
               <SearchTagItemInput
                 type="checkbox"
-                id={item}
+                id={`tags${index}`}
                 value={item}
                 onChange={(e) => handleCheckTag(e)}
               />
-              <SearchTagItemLabel htmlFor={item} className="label-tag">
+              <SearchTagItemLabel
+                htmlFor={`tags${index}`}
+                className="label-tag"
+              >
                 {item}
               </SearchTagItemLabel>
             </SearchTagItem>

--- a/src/styles/components/common/SearchForm.tsx
+++ b/src/styles/components/common/SearchForm.tsx
@@ -27,6 +27,7 @@ const SearchInputForm = styled.div`
   img {
     position: absolute;
     right: 17px;
+    cursor: pointer;
 
     &:hover {
       opacity: 0.7;

--- a/src/styles/components/common/SearchFormPreview.tsx
+++ b/src/styles/components/common/SearchFormPreview.tsx
@@ -1,13 +1,13 @@
 import styled from "styled-components";
 
 const SearchPreviewWrapper = styled.div`
-  // width: calc(100% - 10px);
   width: 100%;
   background-color: #f0efef;
   max-height: 11rem;
   overflow-y: auto;
   border-radius: 7px;
   z-index: 999;
+  margin-top: 5px;
 
   &::-webkit-scrollbar {
     width: 7px;

--- a/src/styles/components/search/SearchTemplate.tsx
+++ b/src/styles/components/search/SearchTemplate.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 
 const SearchPageWrapper = styled.div`
   display: flex;
+  position: relative;
 
   &.list {
     flex-direction: column;
@@ -9,4 +10,22 @@ const SearchPageWrapper = styled.div`
   }
 `;
 
-export { SearchPageWrapper };
+const SearchTypeBtn = styled.div`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 999;
+  background-color: #0d3471;
+  color: #fff;
+  padding: 6px 25px;
+  font-size: 15px;
+  border-radius: 25px;
+  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.25);
+  cursor: pointer;
+
+  &:hover {
+    background-color: #778da9;
+  }
+`;
+
+export { SearchPageWrapper, SearchTypeBtn };

--- a/src/styles/components/search/listType/SearchCategory.tsx
+++ b/src/styles/components/search/listType/SearchCategory.tsx
@@ -41,7 +41,6 @@ const SearchCategoryItemLabel = styled.label`
   background-color: #fff;
   cursor: pointer;
   font-size: 1rem;
-  font-weight: 600;
   line-height: 1rem;
 `;
 

--- a/src/styles/components/search/listType/SearchItemComment.tsx
+++ b/src/styles/components/search/listType/SearchItemComment.tsx
@@ -86,6 +86,23 @@ const SearchCommentBtn = styled.div`
   gap: 0.5rem;
 `;
 
+const SearchResultEmpty = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 15.5rem;
+  font-size: 16px;
+  color: #a0a0a0;
+`;
+
+const SearchLoadingWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 15.5rem;
+`;
+
 export {
   SearchCommentWrapper,
   SearchCommentTitle,
@@ -98,4 +115,6 @@ export {
   SearchCommentText,
   SearchComment,
   SearchCommentBtn,
+  SearchResultEmpty,
+  SearchLoadingWrapper,
 };

--- a/src/styles/components/search/listType/SearchList.tsx
+++ b/src/styles/components/search/listType/SearchList.tsx
@@ -45,6 +45,7 @@ const SearchListTitle = styled.div``;
 const SearchListItem = styled.div`
   padding: 10px;
   border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+  cursor: pointer;
 `;
 
 const SearchListItemTop = styled.div`
@@ -115,6 +116,15 @@ const SearchListItemContent = styled.div`
 
 const SearchListItemTag = styled.div``;
 
+const SearchResultEmpty = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 20rem;
+  font-size: 16px;
+  color: #a0a0a0;
+`;
+
 export {
   SearchListWrapper,
   SearchListBox,
@@ -129,4 +139,5 @@ export {
   SearchListItemContent,
   SearchListItemTag,
   SearchListItemBottom,
+  SearchResultEmpty,
 };

--- a/src/styles/components/search/listType/SearchTagList.tsx
+++ b/src/styles/components/search/listType/SearchTagList.tsx
@@ -15,7 +15,7 @@ const SearchTagItemLabel = styled.div`
   justify-content: center;
   align-items: center;
   height: 1.75rem;
-  width: 80px;
+  padding: 3px 15px;
   color: #000;
   background-color: #eef3f9;
   cursor: pointer;

--- a/src/styles/components/search/listType/SearchTagList.tsx
+++ b/src/styles/components/search/listType/SearchTagList.tsx
@@ -10,20 +10,7 @@ const SearchTagItem = styled.div`
   margin-right: 10px;
 `;
 
-const SearchTagItemInput = styled.input`
-  appearance: none;
-  margin: 0;
-
-  &:checked + .label-tag {
-    background-color: #bdc8d6;
-  }
-
-  &:hover + .label-tag {
-    opacity: 0.5;
-  }
-`;
-
-const SearchTagItemLabel = styled.label`
+const SearchTagItemLabel = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -36,6 +23,7 @@ const SearchTagItemLabel = styled.label`
   font-weight: 500;
   line-height: 1rem;
   border-radius: 7px;
+  margin-top: 25px;
 
   &.secondary {
     color: #fff;
@@ -43,9 +31,4 @@ const SearchTagItemLabel = styled.label`
   }
 `;
 
-export {
-  SearchTagListWrapper,
-  SearchTagItem,
-  SearchTagItemInput,
-  SearchTagItemLabel,
-};
+export { SearchTagListWrapper, SearchTagItem, SearchTagItemLabel };

--- a/src/styles/components/search/map/KakaoModal.tsx
+++ b/src/styles/components/search/map/KakaoModal.tsx
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+
+const ModalFormWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  height: 500px;
+  width: 500px;
+
+  & > div {
+    position: absolute;
+    top: -50px;
+    left: 0px;
+    width: 600px;
+    height: 600px;
+
+    & > div {
+      border-radius: 0px 0px 20px 20px;
+    }
+  }
+`;
+
+export { ModalFormWrapper };

--- a/src/styles/components/search/mapType/SearchTagList.tsx
+++ b/src/styles/components/search/mapType/SearchTagList.tsx
@@ -14,6 +14,7 @@ const SearchTagItem = styled.div`
 const SearchTagItemInput = styled.input`
   appearance: none;
   margin: 0;
+  cursor: pointer;
 
   &:checked + .label-tag {
     background-color: #bdc8d6;


### PR DESCRIPTION
## 작업사항
- [x] 주소 기준 검색 API 연동
    - [x] 검색창 기능 구현
- [x] 전체 검색 기능 API 연동
    - [x] 거리 저장
    - [x] 카테고리 다중 선택 가능 (checkbox) - 전체 선택 & 단일 선택 가능
    - [x] 모집 상태 저장
    - [x] 최대 모집 인원 저장
    - [x] 태그 값 다중 선택 가능 (checkbox)
- [x] 상세페이지 기능 구현
    - [x] 상세 단순 조회 기능 구현
    - [x] 채팅하기 API 연동
    - [x] 신청하기 API 연동
    - [x] 댓글창 기능 API 연동
    - [x] kakao map 연동

## 비고
- 내용을 적어주세요.

## Github 이슈
- [모임 참여하기 > list형 검색 API 연동](https://github.com/KangHayeonn/together-party-tonight-client/issues/63#issue-1789786358)
- [모임 참여하기 > list형 검색 > 상세 API 연동](https://github.com/KangHayeonn/together-party-tonight-client/issues/64#issue-1789788500)

## 작업일자
- 2023.08.06 ~ 2023.08.07

<br>
